### PR TITLE
feat: add observability with openllmetry

### DIFF
--- a/create-app.ts
+++ b/create-app.ts
@@ -43,6 +43,7 @@ export async function createApp({
   postInstallAction,
   dataSource,
   tools,
+  observability,
 }: InstallAppArgs): Promise<void> {
   const root = path.resolve(appPath);
 
@@ -90,6 +91,7 @@ export async function createApp({
     postInstallAction,
     dataSource,
     tools,
+    observability,
   };
 
   if (frontend) {
@@ -143,5 +145,15 @@ export async function createApp({
       `file://${root}/README.md`,
     )} and learn how to get started.`,
   );
+
+  if (args.observability === "opentelemetry") {
+    console.log(
+      `\n${yellow("Observability")}: Visit the ${terminalLink(
+        "documentation",
+        "https://traceloop.com/docs/openllmetry/integrations",
+      )} to set up the environment variables and start seeing execution traces.`,
+    );
+  }
+
   console.log();
 }

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -16,6 +16,7 @@ export type TemplateDataSource = {
   config: TemplateDataSourceConfig;
 };
 export type TemplateDataSourceType = "none" | "file" | "folder" | "web";
+export type TemplateObservability = "none" | "opentelemetry";
 // Config for both file and folder
 export type FileSourceConfig = {
   path?: string;
@@ -49,4 +50,5 @@ export interface InstallTemplateArgs {
   externalPort?: number;
   postInstallAction?: TemplatePostInstallAction;
   tools?: Tool[];
+  observability?: TemplateObservability;
 }

--- a/questions.ts
+++ b/questions.ts
@@ -429,6 +429,28 @@ export const askQuestions = async (
     }
   }
 
+  if (program.framework === "express" || program.framework === "nextjs") {
+    if (!program.observability) {
+      if (ciInfo.isCI) {
+        program.observability = getPrefOrDefault("observability");
+      }
+    } else {
+      const { observability } = await prompts({
+        type: "select",
+        name: "observability",
+        message: "Would you like to set up observability?",
+        choices: [
+          { title: "No", value: "none" },
+          { title: "OpenTelemetry", value: "opentelemetry" },
+        ],
+        initial: 0,
+      });
+
+      program.observability = observability;
+      preferences.observability = observability;
+    }
+  }
+
   if (!program.model) {
     if (ciInfo.isCI) {
       program.model = getPrefOrDefault("model");

--- a/templates/components/observability/typescript/opentelemetry/index.ts
+++ b/templates/components/observability/typescript/opentelemetry/index.ts
@@ -1,0 +1,12 @@
+import * as traceloop from "@traceloop/node-server-sdk";
+import * as LlamaIndex from "llamaindex";
+
+export const initObservability = () => {
+  traceloop.initialize({
+    appName: "llama-app",
+    disableBatch: true,
+    instrumentModules: {
+      llamaIndex: LlamaIndex,
+    },
+  });
+};

--- a/templates/types/simple/express/index.ts
+++ b/templates/types/simple/express/index.ts
@@ -2,6 +2,7 @@
 import cors from "cors";
 import "dotenv/config";
 import express, { Express, Request, Response } from "express";
+import { initObservability } from "./src/observability";
 import chatRouter from "./src/routes/chat.route";
 
 const app: Express = express();
@@ -10,6 +11,8 @@ const port = parseInt(process.env.PORT || "8000");
 const env = process.env["NODE_ENV"];
 const isDevelopment = !env || env === "development";
 const prodCorsOrigin = process.env["PROD_CORS_ORIGIN"];
+
+initObservability();
 
 app.use(express.json());
 

--- a/templates/types/simple/express/src/observability/init.ts
+++ b/templates/types/simple/express/src/observability/init.ts
@@ -1,0 +1,1 @@
+export const initObservability = () => {};

--- a/templates/types/streaming/express/index.ts
+++ b/templates/types/streaming/express/index.ts
@@ -2,6 +2,7 @@
 import cors from "cors";
 import "dotenv/config";
 import express, { Express, Request, Response } from "express";
+import { initObservability } from "./src/observability";
 import chatRouter from "./src/routes/chat.route";
 
 const app: Express = express();
@@ -10,6 +11,8 @@ const port = parseInt(process.env.PORT || "8000");
 const env = process.env["NODE_ENV"];
 const isDevelopment = !env || env === "development";
 const prodCorsOrigin = process.env["PROD_CORS_ORIGIN"];
+
+initObservability();
 
 app.use(express.json());
 

--- a/templates/types/streaming/express/src/observability/index.ts
+++ b/templates/types/streaming/express/src/observability/index.ts
@@ -1,0 +1,1 @@
+export const initObservability = () => {};

--- a/templates/types/streaming/nextjs/app/api/chat/route.ts
+++ b/templates/types/streaming/nextjs/app/api/chat/route.ts
@@ -1,8 +1,11 @@
+import { initObservability } from "@/app/observability";
 import { StreamingTextResponse } from "ai";
 import { ChatMessage, MessageContent, OpenAI } from "llamaindex";
 import { NextRequest, NextResponse } from "next/server";
 import { createChatEngine } from "./engine";
 import { LlamaIndexStream } from "./llamaindex-stream";
+
+initObservability();
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";

--- a/templates/types/streaming/nextjs/app/observability/index.ts
+++ b/templates/types/streaming/nextjs/app/observability/index.ts
@@ -1,0 +1,1 @@
+export const initObservability = () => {};

--- a/templates/types/streaming/nextjs/package.json
+++ b/templates/types/streaming/nextjs/package.json
@@ -24,7 +24,7 @@
     "remark-code-import": "^1.2.0",
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
-    "supports-color": "^9.4.0",
+    "supports-color": "^8.1.1",
     "tailwind-merge": "^2.1.0"
   },
   "devDependencies": {

--- a/templates/types/streaming/nextjs/webpack.config.o11y.mjs
+++ b/templates/types/streaming/nextjs/webpack.config.o11y.mjs
@@ -1,0 +1,16 @@
+export default function webpack(config, isServer) {
+  // See https://webpack.js.org/configuration/resolve/#resolvealias
+  config.resolve.alias = {
+    ...config.resolve.alias,
+    sharp$: false,
+    "onnxruntime-node$": false,
+  };
+  config.module.rules.push({
+    test: /\.node$/,
+    loader: "node-loader",
+  });
+  if (isServer) {
+    config.ignoreWarnings = [{ module: /opentelemetry/ }];
+  }
+  return config;
+}


### PR DESCRIPTION
Add an option to install [OpenLLMetry](https://github.com/traceloop/openllmetry) for OpenTelemetry-based observability in Next.js template of create-llama CLI.

Supersedes https://github.com/run-llama/LlamaIndexTS/pull/612