### PR TITLE
fix: don't create devcontainer if it exists

### DIFF
--- a/helpers/devcontainer.ts
+++ b/helpers/devcontainer.ts
@@ -46,13 +46,16 @@ export const writeDevcontainer = async (
   framework: TemplateFramework,
   frontend: boolean,
 ) => {
-  console.log("Adding .devcontainer");
+  const devcontainerDir = path.join(root, ".devcontainer");
+  if (fs.existsSync(devcontainerDir)) {
+    console.log("Template already has a .devcontainer. Using it.");
+    return;
+  }
   const devcontainerContent = renderDevcontainerContent(
     templatesDir,
     framework,
     frontend,
   );
-  const devcontainerDir = path.join(root, ".devcontainer");
   fs.mkdirSync(devcontainerDir);
   await fs.promises.writeFile(
     path.join(devcontainerDir, "devcontainer.json"),


### PR DESCRIPTION
fixes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the development container setup process by checking for the existence of the `.devcontainer` directory before attempting to create it, enhancing efficiency and reducing unnecessary operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->