### PR TITLE
feat: Use poetry run generate to generate embeddings for FastAPI

### DIFF
--- a/.changeset/four-tools-buy.md
+++ b/.changeset/four-tools-buy.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+Use poetry run generate to generate embeddings for FastAPI

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then re-start your app. Remember you'll need to re-run `generate` if you add new
 If you're using the Python backend, you can trigger indexing of your data by calling:
 
 ```bash
-poetry run python app/engine/generate.py
+poetry run generate
 ```
 
 ## Want a front-end?

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -33,7 +33,7 @@ async function generateContextData(
   if (packageManager) {
     const runGenerate = `${cyan(
       framework === "fastapi"
-        ? "poetry run python app/engine/generate.py"
+        ? "poetry run generate"
         : `${packageManager} run generate`,
     )}`;
     const openAiKeyConfigured = openAiKey || process.env["OPENAI_API_KEY"];
@@ -46,7 +46,7 @@ async function generateContextData(
       if (framework === "fastapi") {
         if (isHavingPoetryLockFile()) {
           console.log(`Running ${runGenerate} to generate the context data.`);
-          const result = tryPoetryRun("python app/engine/generate.py");
+          const result = tryPoetryRun("poetry run generate");
           if (!result) {
             console.log(`Failed to run ${runGenerate}.`);
             process.exit(1);

--- a/helpers/typescript.ts
+++ b/helpers/typescript.ts
@@ -200,7 +200,7 @@ async function updatePackageJson({
   packageJson.name = appName;
   packageJson.version = "0.1.0";
 
-  if (dataSources.length > 0 && relativeEngineDestPath) {
+  if (relativeEngineDestPath) {
     // TODO: move script to {root}/scripts for all frameworks
     // add generate script if using context engine
     packageJson.scripts = {

--- a/templates/components/engines/python/chat/__init__.py
+++ b/templates/components/engines/python/chat/__init__.py
@@ -9,7 +9,7 @@ def get_chat_engine():
     index = get_index()
     if index is None:
         raise Exception(
-            "StorageContext is empty - call 'python app/engine/generate.py' to generate the storage first"
+            "StorageContext is empty - call 'poetry run generate' to generate the storage first"
         )
 
     return index.as_chat_engine(

--- a/templates/components/vectordbs/python/astra/generate.py
+++ b/templates/components/vectordbs/python/astra/generate.py
@@ -15,6 +15,7 @@ logger = logging.getLogger()
 
 
 def generate_datasource():
+    init_settings()
     logger.info("Creating new index")
     documents = get_documents()
     store = AstraDBVectorStore(
@@ -33,5 +34,4 @@ def generate_datasource():
 
 
 if __name__ == "__main__":
-    init_settings()
     generate_datasource()

--- a/templates/components/vectordbs/python/milvus/generate.py
+++ b/templates/components/vectordbs/python/milvus/generate.py
@@ -15,6 +15,7 @@ logger = logging.getLogger()
 
 
 def generate_datasource():
+    init_settings()
     logger.info("Creating new index")
     # load the documents and create the index
     documents = get_documents()
@@ -35,5 +36,4 @@ def generate_datasource():
 
 
 if __name__ == "__main__":
-    init_settings()
     generate_datasource()

--- a/templates/components/vectordbs/python/mongo/generate.py
+++ b/templates/components/vectordbs/python/mongo/generate.py
@@ -15,6 +15,7 @@ logger = logging.getLogger()
 
 
 def generate_datasource():
+    init_settings()
     logger.info("Creating new index")
     # load the documents and create the index
     documents = get_documents()
@@ -39,5 +40,4 @@ See https://github.com/run-llama/mongodb-demo/tree/main?tab=readme-ov-file#creat
 
 
 if __name__ == "__main__":
-    init_settings()
     generate_datasource()

--- a/templates/components/vectordbs/python/none/generate.py
+++ b/templates/components/vectordbs/python/none/generate.py
@@ -16,6 +16,7 @@ logger = logging.getLogger()
 
 
 def generate_datasource():
+    init_settings()
     logger.info("Creating new index")
     # load the documents and create the index
     documents = get_documents()
@@ -28,5 +29,4 @@ def generate_datasource():
 
 
 if __name__ == "__main__":
-    init_settings()
     generate_datasource()

--- a/templates/components/vectordbs/python/pg/generate.py
+++ b/templates/components/vectordbs/python/pg/generate.py
@@ -15,6 +15,7 @@ logger = logging.getLogger()
 
 
 def generate_datasource():
+    init_settings()
     logger.info("Creating new index")
     # load the documents and create the index
     documents = get_documents()
@@ -31,5 +32,4 @@ def generate_datasource():
 
 
 if __name__ == "__main__":
-    init_settings()
     generate_datasource()

--- a/templates/components/vectordbs/python/pinecone/generate.py
+++ b/templates/components/vectordbs/python/pinecone/generate.py
@@ -15,6 +15,7 @@ logger = logging.getLogger()
 
 
 def generate_datasource():
+    init_settings()
     logger.info("Creating new index")
     # load the documents and create the index
     documents = get_documents()
@@ -35,5 +36,4 @@ def generate_datasource():
 
 
 if __name__ == "__main__":
-    init_settings()
     generate_datasource()

--- a/templates/types/streaming/fastapi/README-template.md
+++ b/templates/types/streaming/fastapi/README-template.md
@@ -24,7 +24,7 @@ If you are using any tools or data sources, you can update their config files in
 Second, generate the embeddings of the documents in the `./data` directory (if this folder exists - otherwise, skip this step):
 
 ```
-python app/engine/generate.py
+poetry run generate
 ```
 
 Third, run the development server:
@@ -84,7 +84,7 @@ docker run \
   -v $(pwd)/data:/app/data \ # Use your local folder to read the data
   -v $(pwd)/storage:/app/storage \ # Use your file system to store the vector database
   <your_backend_image_name> \
-  python app/engine/generate.py
+  poetry run generate
 ```
 
 3. Start the API:

--- a/templates/types/streaming/fastapi/pyproject.toml
+++ b/templates/types/streaming/fastapi/pyproject.toml
@@ -5,6 +5,9 @@ description = ""
 authors = ["Marcus Schiesser <mail@marcusschiesser.de>"]
 readme = "README.md"
 
+[tool.poetry.scripts]
+generate = "app.engine.generate:generate_datasource"
+
 [tool.poetry.dependencies]
 python = "^3.11,<3.12"
 fastapi = "^0.109.1"


### PR DESCRIPTION
- remove simple chat engine
- always allow generate context data
- add python script: `poetry run generate` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved command readability and structure in data generation for the `fastapi` framework.
	- Enhanced code organization in Python chat engine and vector database generation scripts.
- **New Features**
	- Standardized script execution process across various components and documentation.
- **Documentation**
	- Updated README files for consistent script execution instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->