### PR TITLE
refactor: use tsx instead of ts-node

### DIFF
--- a/.changeset/lovely-mayflies-appear.md
+++ b/.changeset/lovely-mayflies-appear.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+refactor: use tsx instead of ts-node

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Install NodeJS. Preferably v18 using nvm or n.
 Inside the `create-llama` directory:
 
 ```
-npm i -g pnpm tsx
+npm i -g pnpm 
 pnpm install
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Install NodeJS. Preferably v18 using nvm or n.
 Inside the `create-llama` directory:
 
 ```
-npm i -g pnpm ts-node
+npm i -g pnpm tsx
 pnpm install
 ```
 

--- a/helpers/typescript.ts
+++ b/helpers/typescript.ts
@@ -205,7 +205,7 @@ async function updatePackageJson({
     // add generate script if using context engine
     packageJson.scripts = {
       ...packageJson.scripts,
-      generate: `ts-node ${path.join(
+      generate: `tsx ${path.join(
         relativeEngineDestPath,
         "engine",
         "generate.ts",

--- a/templates/types/streaming/express/package.json
+++ b/templates/types/streaming/express/package.json
@@ -26,7 +26,7 @@
     "nodemon": "^3.0.1",
     "prettier": "^3.2.5",
     "prettier-plugin-organize-imports": "^3.2.4",
-    "ts-node": "^10.9.2",
+    "tsx": "^4.7.2",
     "tsup": "^8.0.1",
     "typescript": "^5.3.2"
   }

--- a/templates/types/streaming/express/tsconfig.json
+++ b/templates/types/streaming/express/tsconfig.json
@@ -9,10 +9,5 @@
     "paths": {
       "@/*": ["./*"]
     }
-  },
-  "ts-node": {
-    "compilerOptions": {
-      "module": "commonjs"
-    }
   }
 }

--- a/templates/types/streaming/nextjs/package.json
+++ b/templates/types/streaming/nextjs/package.json
@@ -44,7 +44,7 @@
     "prettier": "^3.2.5",
     "prettier-plugin-organize-imports": "^3.2.4",
     "tailwindcss": "^3.3.6",
-    "ts-node": "^10.9.2",
+    "tsx": "^4.7.2",
     "typescript": "^5.3.2"
   }
 }

--- a/templates/types/streaming/nextjs/tsconfig.json
+++ b/templates/types/streaming/nextjs/tsconfig.json
@@ -24,10 +24,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"],
-  "ts-node": {
-    "compilerOptions": {
-      "module": "commonjs"
-    }
-  }
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the installation command in the contributing guide.

- **New Features**
	- Transitioned from `ts-node` to `tsx` for script execution in various project templates, enhancing performance and compatibility.

- **Refactor**
	- Simplified TypeScript configurations by removing specific `ts-node` settings, improving maintainability and potentially affecting module resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->