### PR TITLE
Fix escaping double quotes in vercel_response.py

### DIFF
--- a/templates/types/streaming/fastapi/app/api/routers/vercel_response.py
+++ b/templates/types/streaming/fastapi/app/api/routers/vercel_response.py
@@ -13,8 +13,8 @@ class VercelStreamResponse(StreamingResponse):
 
     @classmethod
     def convert_text(cls, token: str):
-        # Escape newlines to avoid breaking the stream
-        token = token.replace("\n", "\\n")
+        # Escape newlines and double quotes to avoid breaking the stream
+        token = token.replace("\n", "\\n").replace('"', '\\"')
         return f'{cls.TEXT_PREFIX}"{token}"\n'
 
     @classmethod

--- a/templates/types/streaming/fastapi/app/api/routers/vercel_response.py
+++ b/templates/types/streaming/fastapi/app/api/routers/vercel_response.py
@@ -14,8 +14,8 @@ class VercelStreamResponse(StreamingResponse):
     @classmethod
     def convert_text(cls, token: str):
         # Escape newlines and double quotes to avoid breaking the stream
-        token = token.replace("\n", "\\n").replace('"', '\\"')
-        return f'{cls.TEXT_PREFIX}"{token}"\n'
+        token = json.dumps(token)
+        return f"{cls.TEXT_PREFIX}{token}\n"
 
     @classmethod
     def convert_data(cls, data: dict):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the text conversion method to prevent stream breakage by escaping newlines and double quotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->