### PR TITLE
chore: bump to llamaindex 0.3

### DIFF
--- a/templates/components/engines/typescript/agent/chat.ts
+++ b/templates/components/engines/typescript/agent/chat.ts
@@ -1,4 +1,4 @@
-import { BaseTool, OpenAIAgent, QueryEngineTool } from "llamaindex";
+import { BaseToolWithCall, OpenAIAgent, QueryEngineTool } from "llamaindex";
 import { ToolsFactory } from "llamaindex/tools/ToolsFactory";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -6,7 +6,7 @@ import { getDataSource } from "./index";
 import { STORAGE_CACHE_DIR } from "./shared";
 
 export async function createChatEngine() {
-  let tools: BaseTool[] = [];
+  let tools: BaseToolWithCall[] = [];
 
   // Add a query engine tool if we have a data source
   // Delete this code if you don't have a data source

--- a/templates/types/streaming/express/package.json
+++ b/templates/types/streaming/express/package.json
@@ -14,7 +14,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "llamaindex": "0.2.10"
+    "llamaindex": "0.3.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.16",

--- a/templates/types/streaming/nextjs/package.json
+++ b/templates/types/streaming/nextjs/package.json
@@ -17,7 +17,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^1.2.1",
     "dotenv": "^16.3.1",
-    "llamaindex": "0.2.10",
+    "llamaindex": "0.3.1",
     "lucide-react": "^0.294.0",
     "next": "^14.0.3",
     "react": "^18.2.0",

--- a/templates/types/streaming/nextjs/webpack.config.mjs
+++ b/templates/types/streaming/nextjs/webpack.config.mjs
@@ -1,15 +1,4 @@
 // webpack config must be a function in NextJS that is used to patch the default webpack config provided by NextJS, see https://nextjs.org/docs/pages/api-reference/next-config-js/webpack
 export default function webpack(config) {
-  config.resolve.fallback = {
-    aws4: false,
-  };
-
-  // Following lines will fix issues with onnxruntime-node when using pnpm
-  // See: https://github.com/vercel/next.js/issues/43433
-  config.externals.push({
-    "onnxruntime-node": "commonjs onnxruntime-node",
-    sharp: "commonjs sharp",
-  });
-
   return config;
 }

--- a/templates/types/streaming/nextjs/webpack.config.o11y.mjs
+++ b/templates/types/streaming/nextjs/webpack.config.o11y.mjs
@@ -1,7 +1,4 @@
 export default function webpack(config, isServer) {
-  config.resolve.fallback = {
-    aws4: false,
-  };
   config.module.rules.push({
     test: /\.node$/,
     loader: "node-loader",


### PR DESCRIPTION
We don't need modify webpack anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Updates**
  - Updated the `llamaindex` package from version `0.2.10` to `0.3.1` to introduce potential new features and improvements.

- **Configuration Changes**
  - Removed specific dependency resolution and external module handling configurations in the NextJS webpack setup.
  - Eliminated the `aws4` fallback configuration in the NextJS webpack setup for streaming types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->