### PR TITLE
Add persist index store for Simple Vector Store

### DIFF
--- a/templates/components/vectordbs/python/none/vectordb.py
+++ b/templates/components/vectordbs/python/none/vectordb.py
@@ -6,10 +6,11 @@ from app.constants import STORAGE_DIR
 
 def get_vector_store():
     if not os.path.exists(STORAGE_DIR):
+        # Vector store hasn't been persisted before, create a new one
         vector_store = SimpleVectorStore()
     else:
+        # Vector store has already been persisted before at STORAGE_DIR - load it
         vector_store = SimpleVectorStore.from_persist_dir(
             STORAGE_DIR, namespace="default"
         )
-    vector_store.stores_text = True
     return vector_store

--- a/templates/components/vectordbs/python/none/vectordb.py
+++ b/templates/components/vectordbs/python/none/vectordb.py
@@ -8,6 +8,8 @@ def get_vector_store():
     if not os.path.exists(STORAGE_DIR):
         vector_store = SimpleVectorStore()
     else:
-        vector_store = SimpleVectorStore.from_persist_dir(STORAGE_DIR)
+        vector_store = SimpleVectorStore.from_persist_dir(
+            STORAGE_DIR, namespace="default"
+        )
     vector_store.stores_text = True
     return vector_store

--- a/templates/types/streaming/fastapi/app/engine/generate.py
+++ b/templates/types/streaming/fastapi/app/engine/generate.py
@@ -70,10 +70,9 @@ def generate_datasource():
             ),
             store_nodes_override=True,
         )
-        # SimpleDocumentStore keeps the data in memory only - needs to be persisted explicitly
         index.storage_context.persist(STORAGE_DIR)
     else:
-        # Persist the docstore to apply ingestion strategy
+        # SimpleDocumentStore keeps the data in memory only - needs to be persisted explicitly
         docstore.persist(os.path.join(STORAGE_DIR, DEFAULT_PERSIST_FNAME))
 
     logger.info("Finished creating new index.")

--- a/templates/types/streaming/fastapi/app/engine/generate.py
+++ b/templates/types/streaming/fastapi/app/engine/generate.py
@@ -72,7 +72,7 @@ def persist_storage(docstore, vector_store, nodes):
 
 def generate_datasource():
     init_settings()
-    logger.info("Indexing the data")
+    logger.info("Generate index for the provided data")
 
     # Get the stores and documents or create new ones
     documents = get_documents()
@@ -89,7 +89,7 @@ def generate_datasource():
     # Build the index and persist storage
     persist_storage(docstore, vector_store, nodes)
 
-    logger.info("Finished the indexing")
+    logger.info("Finished generating the index")
 
 
 if __name__ == "__main__":

--- a/templates/types/streaming/fastapi/app/engine/generate.py
+++ b/templates/types/streaming/fastapi/app/engine/generate.py
@@ -9,6 +9,9 @@ from llama_index.core.ingestion import IngestionPipeline
 from llama_index.core.node_parser import SentenceSplitter
 from llama_index.core.vector_stores import SimpleVectorStore
 from llama_index.core.storage.docstore import SimpleDocumentStore
+from llama_index.core.storage.index_store import SimpleIndexStore
+from llama_index.core.storage import StorageContext
+from llama_index.core import VectorStoreIndex
 from app.constants import STORAGE_DIR
 from app.settings import init_settings
 from app.engine.loaders import get_documents
@@ -54,14 +57,23 @@ def generate_datasource():
     ingestion_pipeline.vector_store = vector_store
 
     # Run the ingestion pipeline and store the results
-    ingestion_pipeline.run(show_progress=True, documents=documents)
+    nodes = ingestion_pipeline.run(show_progress=True, documents=documents)
 
     # Default vector store only keeps data in memory, so we need to persist it
     # Can remove if using a different vector store
     if isinstance(vector_store, SimpleVectorStore):
-        vector_store.persist(os.path.join(STORAGE_DIR, "vector_store.json"))
-    # Persist the docstore to apply ingestion strategy
-    docstore.persist(os.path.join(STORAGE_DIR, "docstore.json"))
+        index = VectorStoreIndex(
+            nodes=nodes,
+            storage_context=StorageContext.from_defaults(
+                docstore=docstore,
+                vector_store=vector_store,
+            ),
+            store_nodes_override=True,
+        )
+        index.storage_context.persist(STORAGE_DIR)
+    else:
+        # Persist the docstore to apply ingestion strategy
+        docstore.docstore.persist(os.path.join(STORAGE_DIR, "docstore.json"))
 
     logger.info("Finished creating new index.")
 

--- a/templates/types/streaming/fastapi/app/engine/generate.py
+++ b/templates/types/streaming/fastapi/app/engine/generate.py
@@ -9,9 +9,9 @@ from llama_index.core.ingestion import IngestionPipeline
 from llama_index.core.node_parser import SentenceSplitter
 from llama_index.core.vector_stores import SimpleVectorStore
 from llama_index.core.storage.docstore import SimpleDocumentStore
-from llama_index.core.storage.index_store import SimpleIndexStore
 from llama_index.core.storage import StorageContext
 from llama_index.core import VectorStoreIndex
+from llama_index.core.storage.docstore.types import DEFAULT_PERSIST_FNAME
 from app.constants import STORAGE_DIR
 from app.settings import init_settings
 from app.engine.loaders import get_documents
@@ -59,8 +59,8 @@ def generate_datasource():
     # Run the ingestion pipeline and store the results
     nodes = ingestion_pipeline.run(show_progress=True, documents=documents)
 
-    # Default vector store only keeps data in memory, so we need to persist it
-    # Can remove if using a different vector store
+    # SimpleVectorStore keeps the data in memory only - needs to be persisted explicitly
+    # Can be removed if using a different vector store
     if isinstance(vector_store, SimpleVectorStore):
         index = VectorStoreIndex(
             nodes=nodes,
@@ -70,10 +70,11 @@ def generate_datasource():
             ),
             store_nodes_override=True,
         )
+        # SimpleDocumentStore keeps the data in memory only - needs to be persisted explicitly
         index.storage_context.persist(STORAGE_DIR)
     else:
         # Persist the docstore to apply ingestion strategy
-        docstore.persist(os.path.join(STORAGE_DIR, "docstore.json"))
+        docstore.persist(os.path.join(STORAGE_DIR, DEFAULT_PERSIST_FNAME))
 
     logger.info("Finished creating new index.")
 

--- a/templates/types/streaming/fastapi/app/engine/generate.py
+++ b/templates/types/streaming/fastapi/app/engine/generate.py
@@ -73,7 +73,7 @@ def generate_datasource():
         index.storage_context.persist(STORAGE_DIR)
     else:
         # Persist the docstore to apply ingestion strategy
-        docstore.docstore.persist(os.path.join(STORAGE_DIR, "docstore.json"))
+        docstore.persist(os.path.join(STORAGE_DIR, "docstore.json"))
 
     logger.info("Finished creating new index.")
 

--- a/templates/types/streaming/fastapi/app/engine/index.py
+++ b/templates/types/streaming/fastapi/app/engine/index.py
@@ -1,5 +1,9 @@
 import logging
+from llama_index.core import load_index_from_storage
+from llama_index.core.storage import StorageContext
 from llama_index.core.indices.vector_store import VectorStoreIndex
+from llama_index.core.vector_stores.simple import SimpleVectorStore
+from app.constants import STORAGE_DIR
 from app.engine.vectordb import get_vector_store
 
 logger = logging.getLogger("uvicorn")
@@ -8,6 +12,16 @@ logger = logging.getLogger("uvicorn")
 def get_index():
     logger.info("Loading the index...")
     store = get_vector_store()
-    index = VectorStoreIndex.from_vector_store(store)
+    # If the store is a SimpleVectorStore, we need to load the index from the storage
+    if isinstance(store, SimpleVectorStore):
+        index = load_index_from_storage(
+            StorageContext.from_defaults(
+                vector_store=store,
+                persist_dir=STORAGE_DIR,
+            )
+        )
+    else:
+        index = VectorStoreIndex.from_vector_store(store)
+
     logger.info("Loaded index successfully.")
     return index

--- a/templates/types/streaming/fastapi/app/settings.py
+++ b/templates/types/streaming/fastapi/app/settings.py
@@ -36,9 +36,9 @@ def init_openai():
     }
     Settings.llm = OpenAI(**config)
 
-    dimension = os.getenv("EMBEDDING_DIM")
+    dimensions = os.getenv("EMBEDDING_DIM")
     config = {
         "model": os.getenv("EMBEDDING_MODEL"),
-        "dimension": int(dimension) if dimension is not None else None,
+        "dimensions": int(dimensions) if dimensions is not None else None,
     }
     Settings.embed_model = OpenAIEmbedding(**config)


### PR DESCRIPTION
To fix the issue of not retrieving any nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced data persistence logic to support different types of vector stores.
	- Improved index loading conditions for more efficient data retrieval.

- **Bug Fixes**
	- Standardized namespace usage in vector storage to "default" for consistency.

- **Refactor**
	- Updated parameter name from `dimension` to `dimensions` in OpenAI initialization settings for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->