### PR TITLE
feat: use 3.5 as default model

### DIFF
--- a/helpers/providers/openai.ts
+++ b/helpers/providers/openai.ts
@@ -8,7 +8,7 @@ import { questionHandlers } from "../../questions";
 
 const OPENAI_API_URL = "https://api.openai.com/v1";
 
-const DEFAULT_MODEL = "gpt-4-turbo";
+const DEFAULT_MODEL = "gpt-3.5-turbo";
 const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-large";
 
 export async function askOpenAIQuestions({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the default AI model used in the application from "gpt-4-turbo" to "gpt-3.5-turbo."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->