### PR TITLE
fix: import undefined issues in nextjs

### DIFF
--- a/templates/types/streaming/nextjs/webpack.config.mjs
+++ b/templates/types/streaming/nextjs/webpack.config.mjs
@@ -9,6 +9,8 @@ export default function webpack(config) {
   config.externals.push({
     "onnxruntime-node": "commonjs onnxruntime-node",
     sharp: "commonjs sharp",
+    // Fixes issue with import errors where modules cannot be found
+    llamaindex: "commonjs llamaindex",
   });
 
   return config;


### PR DESCRIPTION
Bug Fixes

- Fixes issues with modules imported from `llamaindex` being `undefined`. Example issue: https://github.com/run-llama/create-llama/issues/78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved module compatibility in the build configuration to enhance the app's performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->