### PR TITLE
fix: qdrant store init parameters

### DIFF
--- a/templates/components/vectordbs/typescript/qdrant/generate.ts
+++ b/templates/components/vectordbs/typescript/qdrant/generate.ts
@@ -18,7 +18,10 @@ async function loadAndIndex() {
   const documents = await getDocuments();
 
   // Connect to Qdrant
-  const vectorStore = new QdrantVectorStore(collectionName, getQdrantClient());
+  const vectorStore = new QdrantVectorStore({
+    collectionName,
+    client: getQdrantClient(),
+  });
 
   const storageContext = await storageContextFromDefaults({ vectorStore });
   await VectorStoreIndex.fromDocuments(documents, {

--- a/templates/components/vectordbs/typescript/qdrant/index.ts
+++ b/templates/components/vectordbs/typescript/qdrant/index.ts
@@ -7,7 +7,10 @@ dotenv.config();
 export async function getDataSource() {
   checkRequiredEnvVars();
   const collectionName = process.env.QDRANT_COLLECTION;
-  const store = new QdrantVectorStore(collectionName, getQdrantClient());
+  const store = new QdrantVectorStore({
+    collectionName,
+    client: getQdrantClient(),
+  });
 
   return await VectorStoreIndex.fromVectorStore(store);
 }


### PR DESCRIPTION
Bug Fixes

- Fixes issues with TypeScript `QdrantVectorStore` initialisation, where the constructor parameters are incorrectly provided. For reference, here's the constructor as defined in `llamaindex`:

https://github.com/run-llama/LlamaIndexTS/blob/75736ad01baf776f54e1d26f73e25d6faa9667a0/packages/core/src/storage/vectorStore/QdrantVectorStore.ts#L53-L59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the instantiation method for `QdrantVectorStore` by using an object parameter for better clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->