### PR TITLE
feat: support display latex in chat markdown

### DIFF
--- a/.changeset/silent-tomatoes-relax.md
+++ b/.changeset/silent-tomatoes-relax.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+feat: support display latex in chat markdown

--- a/templates/types/streaming/nextjs/app/components/ui/chat/markdown.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/markdown.tsx
@@ -1,9 +1,9 @@
+import "katex/dist/katex.min.css";
 import { FC, memo } from "react";
 import ReactMarkdown, { Options } from "react-markdown";
+import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
-import rehypeKatex from "rehype-katex";
-import 'katex/dist/katex.min.css';
 
 import { CodeBlock } from "./codeblock";
 
@@ -34,7 +34,7 @@ export default function Markdown({ content }: { content: string }) {
     <MemoizedReactMarkdown
       className="prose dark:prose-invert prose-p:leading-relaxed prose-pre:p-0 break-words custom-markdown"
       remarkPlugins={[remarkGfm, remarkMath]}
-      rehypePlugins={[rehypeKatex as any]} 
+      rehypePlugins={[rehypeKatex as any]}
       components={{
         p({ children }) {
           return <p className="mb-2 last:mb-0">{children}</p>;

--- a/templates/types/streaming/nextjs/app/components/ui/chat/markdown.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/markdown.tsx
@@ -2,6 +2,8 @@ import { FC, memo } from "react";
 import ReactMarkdown, { Options } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
+import 'katex/dist/katex.min.css';
 
 import { CodeBlock } from "./codeblock";
 
@@ -12,11 +14,27 @@ const MemoizedReactMarkdown: FC<Options> = memo(
     prevProps.className === nextProps.className,
 );
 
+const preprocessLaTeX = (content: string) => {
+  // Replace block-level LaTeX delimiters \[ \] with $$ $$
+  const blockProcessedContent = content.replace(
+    /\\\[(.*?)\\\]/gs,
+    (_, equation) => `$$${equation}$$`,
+  );
+  // Replace inline LaTeX delimiters \( \) with $ $
+  const inlineProcessedContent = blockProcessedContent.replace(
+    /\\\((.*?)\\\)/gs,
+    (_, equation) => `$${equation}$`,
+  );
+  return inlineProcessedContent;
+};
+
 export default function Markdown({ content }: { content: string }) {
+  const processedContent = preprocessLaTeX(content);
   return (
     <MemoizedReactMarkdown
       className="prose dark:prose-invert prose-p:leading-relaxed prose-pre:p-0 break-words custom-markdown"
       remarkPlugins={[remarkGfm, remarkMath]}
+      rehypePlugins={[rehypeKatex as any]} 
       components={{
         p({ children }) {
           return <p className="mb-2 last:mb-0">{children}</p>;
@@ -53,7 +71,7 @@ export default function Markdown({ content }: { content: string }) {
         },
       }}
     >
-      {content}
+      {processedContent}
     </MemoizedReactMarkdown>
   );
 }

--- a/templates/types/streaming/nextjs/package.json
+++ b/templates/types/streaming/nextjs/package.json
@@ -30,6 +30,7 @@
     "remark-code-import": "^1.2.0",
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
+    "rehype-katex": "^7.0.0",
     "supports-color": "^8.1.1",
     "tailwind-merge": "^2.1.0"
   },


### PR DESCRIPTION
![image](https://github.com/run-llama/create-llama/assets/51660321/7fec25a6-c4c5-415e-aa15-344b838690fd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved rendering of LaTeX equations in Markdown content using KaTeX.
  
- **Dependencies**
  - Added `rehype-katex` dependency for enhanced LaTeX rendering capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->