### PR TITLE
chore: always generate tools config if user selects agent mode

### DIFF
--- a/helpers/tools.ts
+++ b/helpers/tools.ts
@@ -159,7 +159,6 @@ export const writeToolsConfig = async (
   tools: Tool[] = [],
   type: ConfigFileType = ConfigFileType.YAML,
 ) => {
-  if (tools.length === 0) return; // no tools selected, no config need
   const configContent: {
     [key in ToolType]: Record<string, any>;
   } = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where configuration updates would not proceed if no tools were selected. Now, the configuration process continues regardless of the number of tools selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->