### PR TITLE
bump llama-index-agent-openai version to 0.2.6

### DIFF
--- a/helpers/python.ts
+++ b/helpers/python.ts
@@ -144,7 +144,7 @@ const getAdditionalDependencies = (
     case "openai":
       dependencies.push({
         name: "llama-index-agent-openai",
-        version: "0.2.2",
+        version: "0.2.6",
       });
       break;
     case "anthropic":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the dependency version of `"llama-index-agent-openai"` from `"0.2.2"` to `"0.2.6"`. This ensures compatibility with the latest features and bug fixes of the dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->