### PR TITLE
refactor: use annotations instead of data

### DIFF
--- a/templates/types/streaming/fastapi/app/api/routers/models.py
+++ b/templates/types/streaming/fastapi/app/api/routers/models.py
@@ -81,7 +81,7 @@ class ChatData(BaseModel):
 
     def get_last_message_content(self) -> str:
         """
-        Get the content of the last message along with the data content if available
+        Get the content of the last message along with the data content if available. Fallback to use data content from previous messages
         """
         if len(self.messages) == 0:
             raise ValueError("There is not any message in the chat")

--- a/templates/types/streaming/fastapi/app/api/routers/models.py
+++ b/templates/types/streaming/fastapi/app/api/routers/models.py
@@ -2,7 +2,7 @@ import os
 import logging
 from pydantic import BaseModel, Field, validator
 from pydantic.alias_generators import to_camel
-from typing import List, Any, Optional, Dict, Any
+from typing import List, Any, Optional, Dict
 from llama_index.core.schema import NodeWithScore
 from llama_index.core.llms import ChatMessage, MessageRole
 

--- a/templates/types/streaming/nextjs/app/components/ui/chat/chat-input.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/chat-input.tsx
@@ -63,17 +63,12 @@ export default function ChatInput(
     attachments: JSONValue[] | undefined,
   ) => {
     e.preventDefault();
-    props.append!(
-      {
-        content: props.input,
-        role: "user",
-        createdAt: new Date(),
-        annotations: attachments,
-      },
-      {
-        data: { imageUrl, csvFiles: files },
-      },
-    );
+    props.append!({
+      content: props.input,
+      role: "user",
+      createdAt: new Date(),
+      annotations: attachments,
+    });
     setImageUrl(null);
     resetUploadedFiles();
     props.setInput!("");

--- a/templates/types/streaming/nextjs/app/components/ui/chat/chat-input.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/chat-input.tsx
@@ -1,5 +1,4 @@
 import { JSONValue } from "ai";
-import { Loader2 } from "lucide-react";
 import { useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { MessageAnnotation, MessageAnnotationType } from ".";
@@ -26,12 +25,15 @@ export default function ChatInput(
   >,
 ) {
   const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const { files, uploadNew, removeFile, resetUploadedFiles } = useCsv(
-    props.messages,
-  );
+  const {
+    uploadedFiles: uploadedCsvFiles,
+    uploadNew,
+    removeFile,
+    resetUploadedFiles,
+  } = useCsv();
 
   const getAttachments = () => {
-    if (!imageUrl && files.length === 0) return undefined;
+    if (!imageUrl && uploadedCsvFiles.length === 0) return undefined;
     const annotations: MessageAnnotation[] = [];
     if (imageUrl) {
       annotations.push({
@@ -39,11 +41,11 @@ export default function ChatInput(
         data: { url: imageUrl },
       });
     }
-    if (files.length > 0) {
+    if (uploadedCsvFiles.length > 0) {
       annotations.push({
         type: MessageAnnotationType.CSV,
         data: {
-          csvFiles: files.map((file) => ({
+          csvFiles: uploadedCsvFiles.map((file) => ({
             id: file.id,
             content: file.content,
             filename: file.filename,
@@ -119,7 +121,7 @@ export default function ChatInput(
         return await handleUploadImageFile(file);
       }
       if (file.type === "text/csv") {
-        if (files.length > 0) {
+        if (uploadedCsvFiles.length > 0) {
           alert("You can only upload one csv file at a time.");
           return;
         }
@@ -139,27 +141,17 @@ export default function ChatInput(
       {imageUrl && (
         <UploadImagePreview url={imageUrl} onRemove={onRemovePreviewImage} />
       )}
-      {files.length > 0 && (
+      {uploadedCsvFiles.length > 0 && (
         <div className="flex gap-4 w-full overflow-auto py-2">
-          {props.isLoading ? (
-            <div className="flex gap-2 items-center">
-              <Loader2 className="h-4 w-4 animate-spin" />{" "}
-              <span>Handling csv files...</span>
-            </div>
-          ) : (
-            <>
-              {files.map((csv) => {
-                return (
-                  <UploadCsvPreview
-                    key={csv.id}
-                    csv={csv}
-                    onRemove={() => removeFile(csv)}
-                    isNew={csv.type === "new_upload"}
-                  />
-                );
-              })}
-            </>
-          )}
+          {uploadedCsvFiles.map((csv) => {
+            return (
+              <UploadCsvPreview
+                key={csv.id}
+                csv={csv}
+                onRemove={() => removeFile(csv)}
+              />
+            );
+          })}
         </div>
       )}
       <div className="flex w-full items-start justify-between gap-4 ">

--- a/templates/types/streaming/nextjs/app/components/ui/chat/chat-input.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/chat-input.tsx
@@ -65,12 +65,6 @@ export default function ChatInput(
       createdAt: new Date(),
       annotations: attachments,
     });
-    if (imageUrl) {
-      setImageUrl(null);
-    }
-    if (csvFiles.length > 0) {
-      reset();
-    }
     props.setInput!("");
   };
 
@@ -78,6 +72,8 @@ export default function ChatInput(
     const attachments = getAttachments();
     if (attachments) {
       submitWithAttachment(e, attachments);
+      imageUrl && setImageUrl(null);
+      csvFiles.length && reset();
       return;
     }
     props.handleSubmit(e);

--- a/templates/types/streaming/nextjs/app/components/ui/chat/chat-input.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/chat-input.tsx
@@ -25,15 +25,10 @@ export default function ChatInput(
   >,
 ) {
   const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const {
-    uploadedFiles: uploadedCsvFiles,
-    uploadNew,
-    removeFile,
-    resetUploadedFiles,
-  } = useCsv();
+  const { files: csvFiles, upload, remove, reset } = useCsv();
 
   const getAttachments = () => {
-    if (!imageUrl && uploadedCsvFiles.length === 0) return undefined;
+    if (!imageUrl && csvFiles.length === 0) return undefined;
     const annotations: MessageAnnotation[] = [];
     if (imageUrl) {
       annotations.push({
@@ -41,16 +36,15 @@ export default function ChatInput(
         data: { url: imageUrl },
       });
     }
-    if (uploadedCsvFiles.length > 0) {
+    if (csvFiles.length > 0) {
       annotations.push({
         type: MessageAnnotationType.CSV,
         data: {
-          csvFiles: uploadedCsvFiles.map((file) => ({
+          csvFiles: csvFiles.map((file) => ({
             id: file.id,
             content: file.content,
             filename: file.filename,
             filesize: file.filesize,
-            type: "available",
           })),
         },
       });
@@ -71,8 +65,12 @@ export default function ChatInput(
       createdAt: new Date(),
       annotations: attachments,
     });
-    setImageUrl(null);
-    resetUploadedFiles();
+    if (imageUrl) {
+      setImageUrl(null);
+    }
+    if (csvFiles.length > 0) {
+      reset();
+    }
     props.setInput!("");
   };
 
@@ -104,7 +102,7 @@ export default function ChatInput(
       reader.onload = () => resolve(reader.result as string);
       reader.onerror = (error) => reject(error);
     });
-    const isSuccess = uploadNew({
+    const isSuccess = upload({
       id: uuidv4(),
       content,
       filename: file.name,
@@ -121,7 +119,7 @@ export default function ChatInput(
         return await handleUploadImageFile(file);
       }
       if (file.type === "text/csv") {
-        if (uploadedCsvFiles.length > 0) {
+        if (csvFiles.length > 0) {
           alert("You can only upload one csv file at a time.");
           return;
         }
@@ -141,14 +139,14 @@ export default function ChatInput(
       {imageUrl && (
         <UploadImagePreview url={imageUrl} onRemove={onRemovePreviewImage} />
       )}
-      {uploadedCsvFiles.length > 0 && (
+      {csvFiles.length > 0 && (
         <div className="flex gap-4 w-full overflow-auto py-2">
-          {uploadedCsvFiles.map((csv) => {
+          {csvFiles.map((csv) => {
             return (
               <UploadCsvPreview
                 key={csv.id}
                 csv={csv}
-                onRemove={() => removeFile(csv)}
+                onRemove={() => remove(csv)}
               />
             );
           })}

--- a/templates/types/streaming/nextjs/app/components/ui/chat/chat-input.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/chat-input.tsx
@@ -27,7 +27,7 @@ export default function ChatInput(
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const { files: csvFiles, upload, remove, reset } = useCsv();
 
-  const getAttachments = () => {
+  const getAnnotations = () => {
     if (!imageUrl && csvFiles.length === 0) return undefined;
     const annotations: MessageAnnotation[] = [];
     if (imageUrl) {
@@ -54,24 +54,24 @@ export default function ChatInput(
 
   // default submit function does not handle including annotations in the message
   // so we need to use append function to submit new message with annotations
-  const submitWithAttachment = (
+  const handleSubmitWithAnnotations = (
     e: React.FormEvent<HTMLFormElement>,
-    attachments: JSONValue[] | undefined,
+    annotations: JSONValue[] | undefined,
   ) => {
     e.preventDefault();
     props.append!({
       content: props.input,
       role: "user",
       createdAt: new Date(),
-      annotations: attachments,
+      annotations,
     });
     props.setInput!("");
   };
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    const attachments = getAttachments();
-    if (attachments) {
-      submitWithAttachment(e, attachments);
+    const annotations = getAnnotations();
+    if (annotations) {
+      handleSubmitWithAnnotations(e, annotations);
       imageUrl && setImageUrl(null);
       csvFiles.length && reset();
       return;

--- a/templates/types/streaming/nextjs/app/components/ui/chat/use-csv.ts
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/use-csv.ts
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { CsvFile } from ".";
 
 export function useCsv() {
-  const [uploadedFiles, setUploadedFiles] = useState<CsvFile[]>([]);
+  const [files, setFiles] = useState<CsvFile[]>([]);
 
   const csvEqual = (a: CsvFile, b: CsvFile) => {
     if (a.id === b.id) return true;
@@ -12,27 +12,22 @@ export function useCsv() {
     return false;
   };
 
-  const uploadNew = (file: CsvFile) => {
-    const existedCsv = uploadedFiles.find((f) => csvEqual(f, file));
+  const upload = (file: CsvFile) => {
+    const existedCsv = files.find((f) => csvEqual(f, file));
     if (!existedCsv) {
-      setUploadedFiles((prev) => [...prev, file]);
+      setFiles((prev) => [...prev, file]);
       return true;
     }
     return false;
   };
 
-  const removeFile = (file: CsvFile) => {
-    setUploadedFiles((prev) => prev.filter((f) => f.id !== file.id));
+  const remove = (file: CsvFile) => {
+    setFiles((prev) => prev.filter((f) => f.id !== file.id));
   };
 
-  const resetUploadedFiles = () => {
-    setUploadedFiles([]);
+  const reset = () => {
+    setFiles([]);
   };
 
-  return {
-    uploadedFiles,
-    uploadNew,
-    removeFile,
-    resetUploadedFiles,
-  };
+  return { files, upload, remove, reset };
 }

--- a/templates/types/streaming/nextjs/app/components/ui/chat/use-csv.ts
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/use-csv.ts
@@ -1,31 +1,10 @@
 "use client";
 
-import { Message } from "ai";
-import { useEffect, useMemo, useState } from "react";
-import {
-  CsvData,
-  CsvFile,
-  MessageAnnotation,
-  MessageAnnotationType,
-  getAnnotationData,
-} from ".";
+import { useState } from "react";
+import { CsvFile } from ".";
 
-interface FrontendCSVData extends CsvFile {
-  type: "available" | "new_upload";
-}
-
-export function useCsv(messages: Message[]) {
-  const [availableFiles, setAvailableFiles] = useState<FrontendCSVData[]>([]);
-  const [uploadedFiles, setUploadedFiles] = useState<FrontendCSVData[]>([]);
-
-  const files = useMemo(() => {
-    return [...availableFiles, ...uploadedFiles];
-  }, [availableFiles, uploadedFiles]);
-
-  useEffect(() => {
-    const items = getAvailableCsvFiles(messages);
-    setAvailableFiles(items.map((data) => ({ ...data, type: "available" })));
-  }, [messages]);
+export function useCsv() {
+  const [uploadedFiles, setUploadedFiles] = useState<CsvFile[]>([]);
 
   const csvEqual = (a: CsvFile, b: CsvFile) => {
     if (a.id === b.id) return true;
@@ -33,43 +12,17 @@ export function useCsv(messages: Message[]) {
     return false;
   };
 
-  // Get available csv files from annotations chat history
-  // returns the unique csv files by id
-  const getAvailableCsvFiles = (messages: Message[]): Array<CsvFile> => {
-    const docHash: Record<string, CsvFile> = {};
-    messages.forEach((message) => {
-      if (message.annotations) {
-        const csvData = getAnnotationData<CsvData>(
-          message.annotations as MessageAnnotation[],
-          MessageAnnotationType.CSV,
-        );
-        csvData.forEach((data) => {
-          data.csvFiles.forEach((file) => {
-            if (!docHash[file.id]) {
-              docHash[file.id] = file;
-            }
-          });
-        });
-      }
-    });
-    return Object.values(docHash);
-  };
-
   const uploadNew = (file: CsvFile) => {
-    const existedCsv = files.find((f) => csvEqual(f, file));
+    const existedCsv = uploadedFiles.find((f) => csvEqual(f, file));
     if (!existedCsv) {
-      setUploadedFiles((prev) => [...prev, { ...file, type: "new_upload" }]);
+      setUploadedFiles((prev) => [...prev, file]);
       return true;
     }
     return false;
   };
 
-  const removeFile = (file: FrontendCSVData) => {
-    if (file.type === "new_upload") {
-      setUploadedFiles((prev) => prev.filter((f) => f.id !== file.id));
-    } else {
-      setAvailableFiles((prev) => prev.filter((f) => f.id !== file.id));
-    }
+  const removeFile = (file: CsvFile) => {
+    setUploadedFiles((prev) => prev.filter((f) => f.id !== file.id));
   };
 
   const resetUploadedFiles = () => {
@@ -77,7 +30,7 @@ export function useCsv(messages: Message[]) {
   };
 
   return {
-    files,
+    uploadedFiles,
     uploadNew,
     removeFile,
     resetUploadedFiles,

--- a/templates/types/streaming/nextjs/app/components/ui/upload-csv-preview.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/upload-csv-preview.tsx
@@ -17,7 +17,6 @@ import { cn } from "./lib/utils";
 export interface UploadCsvPreviewProps {
   csv: CsvFile;
   onRemove?: () => void;
-  isNew?: boolean;
 }
 
 export default function UploadCsvPreview(props: UploadCsvPreviewProps) {
@@ -52,7 +51,7 @@ export default function UploadCsvPreview(props: UploadCsvPreviewProps) {
 }
 
 function CSVSummaryCard(props: UploadCsvPreviewProps) {
-  const { onRemove, isNew, csv } = props;
+  const { onRemove, csv } = props;
   return (
     <div className="p-2 w-60 max-w-60 bg-secondary rounded-lg text-sm relative cursor-pointer">
       <div className="flex flex-row items-center gap-2">
@@ -70,11 +69,6 @@ function CSVSummaryCard(props: UploadCsvPreviewProps) {
           </div>
           <div className="truncate text-token-text-tertiary flex items-center gap-2">
             <span>Spreadsheet</span>
-            {isNew && (
-              <span className="px-2 py-0.5 bg-red-400 text-white text-xs rounded-2xl">
-                new
-              </span>
-            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
- remove sending images and CSVs as `data` (avoids sending content twice)
- use annotations to generate `MessageContentDetail[]`
- as GPT4 ignores `MessageContentDetail` from previous messages (only pure string messages seem to be used), fallback to use annotation from last user message 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the `ChatInput` component by grouping related properties into a single object.
  - Updated the `useCsv` hook to streamline state management and file handling.

- **New Features**
  - Improved file upload functionality in the chat input, making it more intuitive and efficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->