### PR TITLE
fix: add allowed file extensions

### DIFF
--- a/templates/types/streaming/nextjs/app/components/ui/chat/chat-input.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/chat-input.tsx
@@ -164,6 +164,10 @@ export default function ChatInput(
         <FileUploader
           onFileUpload={handleUploadFile}
           onFileError={props.onFileError}
+          config={{
+            allowedExtensions: ["jpg", "png", "jpeg", "csv"],
+            disabled: props.isLoading,
+          }}
         />
         <Button type="submit" disabled={props.isLoading || !props.input.trim()}>
           Send message


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced file upload restrictions in the chat input, allowing only "jpg," "png," "jpeg," and "csv" file types.

- **Improvements**
	- The file upload button is now automatically disabled while loading, enhancing user experience during long operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->