### PR TITLE
feat: use LlamaParse for all the supported types

### DIFF
--- a/.changeset/olive-knives-cheat.md
+++ b/.changeset/olive-knives-cheat.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+Use LlamaParse for all the file types that it supports (if activated)

--- a/templates/components/loaders/python/file.py
+++ b/templates/components/loaders/python/file.py
@@ -32,6 +32,13 @@ def llama_parse_parser():
     return parser
 
 
+def llama_parse_extractor() -> Dict[str, LlamaParse]:
+    from llama_parse.utils import SUPPORTED_FILE_TYPES
+
+    parser = llama_parse_parser()
+    return {file_type: parser for file_type in SUPPORTED_FILE_TYPES}
+
+
 def get_file_documents(config: FileLoaderConfig):
     from llama_index.core.readers import SimpleDirectoryReader
 
@@ -46,8 +53,7 @@ def get_file_documents(config: FileLoaderConfig):
 
             nest_asyncio.apply()
 
-            parser = llama_parse_parser()
-            reader.file_extractor = {".pdf": parser}
+            reader.file_extractor = llama_parse_extractor()
         return reader.load_data()
     except Exception as e:
         import sys, traceback

--- a/templates/components/loaders/python/file.py
+++ b/templates/components/loaders/python/file.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from typing import Dict
 from llama_parse import LlamaParse
 from pydantic import BaseModel, validator
 
@@ -43,9 +44,7 @@ def get_file_documents(config: FileLoaderConfig):
     from llama_index.core.readers import SimpleDirectoryReader
 
     try:
-        reader = SimpleDirectoryReader(
-            config.data_dir, recursive=True, filename_as_id=True, raise_on_error=True
-        )
+        file_extractor = None
         if config.use_llama_parse:
             # LlamaParse is async first,
             # so we need to use nest_asyncio to run it in sync mode
@@ -53,7 +52,14 @@ def get_file_documents(config: FileLoaderConfig):
 
             nest_asyncio.apply()
 
-            reader.file_extractor = llama_parse_extractor()
+            file_extractor = llama_parse_extractor()
+        reader = SimpleDirectoryReader(
+            config.data_dir,
+            recursive=True,
+            filename_as_id=True,
+            raise_on_error=True,
+            file_extractor=file_extractor,
+        )
         return reader.load_data()
     except Exception as e:
         import sys, traceback


### PR DESCRIPTION
Do not mere this PR yet!
Having an error with LlamaParse:
```
Error while parsing the file '<bytes/buffer>': file_input must be either a file path string, file bytes, or buffer object
Traceback (most recent call last):
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/llama_index/core/readers/file/base.py", line 538, in load_file
    docs = reader.load_data(input_file, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/llama_parse/base.py", line 343, in load_data
    return asyncio.run(self.aload_data(file_path, extra_info))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/nest_asyncio.py", line 30, in run
    return loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/nest_asyncio.py", line 98, in run_until_complete
    return f.result()
           ^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/futures.py", line 203, in result
    raise self._exception.with_traceback(self._exception_tb)
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/tasks.py", line 267, in __step
    result = coro.send(None)
             ^^^^^^^^^^^^^^^
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/llama_parse/base.py", line 304, in aload_data
    return await self._aload_data(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/llama_parse/base.py", line 295, in _aload_data
    raise e
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/llama_parse/base.py", line 270, in _aload_data
    job_id = await self._create_job(file_path, extra_info=extra_info)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/huu/Library/Caches/pypoetry/virtualenvs/app-p4JNq43d-py3.11/lib/python3.11/site-packages/llama_parse/base.py", line 182, in _create_job
    raise ValueError(
ValueError: file_input must be either a file path string, file bytes, or buffer object
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced LlamaParse for enhanced file parsing across supported file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->