### PR TITLE
chore: bump llama_index version for fastapi template

### DIFF
--- a/templates/types/streaming/fastapi/pyproject.toml
+++ b/templates/types/streaming/fastapi/pyproject.toml
@@ -14,8 +14,8 @@ fastapi = "^0.109.1"
 uvicorn = { extras = ["standard"], version = "^0.23.2" }
 python-dotenv = "^1.0.0"
 aiostream = "^0.5.2"
-llama-index = "0.10.50"
-llama-index-core = "0.10.50"
+llama-index = "0.10.52"
+llama-index-core = "0.10.52.post1"
 cachetools = "^5.3.3"
 
 [build-system]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new LlamaCloud Index functionality, allowing users to configure and use LlamaCloud for indexing based on environment variables.

- **Improvements**
  - Updated `llama-index` and `llama-index-core` dependencies to versions `0.10.52` and `0.10.52.post1`, respectively, improving compatibility and performance.

- **Configuration**
  - Added new environment variables for LlamaCloud configuration.
  - Enhanced logging and error handling for LlamaCloud connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->