### PR TITLE
bump llama-index version

### DIFF
--- a/templates/types/streaming/fastapi/pyproject.toml
+++ b/templates/types/streaming/fastapi/pyproject.toml
@@ -14,8 +14,7 @@ fastapi = "^0.109.1"
 uvicorn = { extras = ["standard"], version = "^0.23.2" }
 python-dotenv = "^1.0.0"
 aiostream = "^0.5.2"
-llama-index = "0.10.52"
-llama-index-core = "0.10.52.post1"
+llama-index = "0.10.53"
 cachetools = "^5.3.3"
 
 [build-system]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `llama-index` dependency to version 0.10.53.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->