### PR TITLE
feat: Use Qdrant FastEmbed as local embedding provider

### DIFF
--- a/.changeset/happy-emus-attend.md
+++ b/.changeset/happy-emus-attend.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+Use Qdrant FastEmbed as local embedding provider

--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,8 @@ e2e/cache
 # intellij
 **/.idea
 
+# Python
+.mypy_cache/
+
 # build artifacts
 create-llama-*.tgz

--- a/helpers/python.ts
+++ b/helpers/python.ts
@@ -153,14 +153,24 @@ const getAdditionalDependencies = (
         version: "0.2.6",
       });
       break;
+    case "groq":
+      dependencies.push({
+        name: "llama-index-llms-groq",
+        version: "0.1.4",
+      });
+      dependencies.push({
+        name: "llama-index-embeddings-fastembed",
+        version: "^0.1.4",
+      });
+      break;
     case "anthropic":
       dependencies.push({
         name: "llama-index-llms-anthropic",
         version: "0.1.10",
       });
       dependencies.push({
-        name: "llama-index-embeddings-huggingface",
-        version: "0.2.0",
+        name: "llama-index-embeddings-fastembed",
+        version: "^0.1.4",
       });
       break;
     case "gemini":

--- a/templates/components/settings/python/settings.py
+++ b/templates/components/settings/python/settings.py
@@ -98,8 +98,25 @@ def init_azure_openai():
     Settings.embed_model = AzureOpenAIEmbedding(**embedding_config)
 
 
+def init_fastembed():
+    """
+    Use Qdrant Fastembed as the local embedding provider.
+    """
+    from llama_index.embeddings.fastembed import FastEmbedEmbedding
+
+    embed_model_map: Dict[str, str] = {
+        # Small and multilingual
+        "all-MiniLM-L6-v2": "sentence-transformers/all-MiniLM-L6-v2",
+        # Large and multilingual
+        "paraphrase-multilingual-mpnet-base-v2": "sentence-transformers/paraphrase-multilingual-mpnet-base-v2",   # noqa: E501
+    }
+
+    # This will download the model automatically if it is not already downloaded
+    Settings.embed_model = FastEmbedEmbedding(
+        model_name=embed_model_map[os.getenv("EMBEDDING_MODEL")]
+    )
+
 def init_groq():
-    from llama_index.embeddings.huggingface import HuggingFaceEmbedding
     from llama_index.llms.groq import Groq
 
     model_map: Dict[str, str] = {
@@ -108,19 +125,13 @@ def init_groq():
         "mixtral-8x7b": "mixtral-8x7b-32768",
     }
 
-    embed_model_map: Dict[str, str] = {
-        "all-MiniLM-L6-v2": "sentence-transformers/all-MiniLM-L6-v2",
-        "all-mpnet-base-v2": "sentence-transformers/all-mpnet-base-v2",
-    }
 
     Settings.llm = Groq(model=model_map[os.getenv("MODEL")])
-    Settings.embed_model = HuggingFaceEmbedding(
-        model_name=embed_model_map[os.getenv("EMBEDDING_MODEL")]
-    )
+    # Groq does not provide embeddings, so we use FastEmbed instead
+    init_fastembed()
 
 
 def init_anthropic():
-    from llama_index.embeddings.huggingface import HuggingFaceEmbedding
     from llama_index.llms.anthropic import Anthropic
 
     model_map: Dict[str, str] = {
@@ -131,15 +142,9 @@ def init_anthropic():
         "claude-instant-1.2": "claude-instant-1.2",
     }
 
-    embed_model_map: Dict[str, str] = {
-        "all-MiniLM-L6-v2": "sentence-transformers/all-MiniLM-L6-v2",
-        "all-mpnet-base-v2": "sentence-transformers/all-mpnet-base-v2",
-    }
-
     Settings.llm = Anthropic(model=model_map[os.getenv("MODEL")])
-    Settings.embed_model = HuggingFaceEmbedding(
-        model_name=embed_model_map[os.getenv("EMBEDDING_MODEL")]
-    )
+    # Anthropic does not provide embeddings, so we use FastEmbed instead
+    init_fastembed()
 
 
 def init_gemini():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Qdrant FastEmbed as the new local embedding provider.

- **Improvements**
  - Updated dependency management to support "groq" case with specific versions of `llama-index-embeddings-fastembed` and `llama-index-llms-groq`.

- **Bug Fixes**
  - Modified initialization functions to use `FastEmbedEmbedding` instead of `HuggingFaceEmbedding` for improved embedding model usage.

- **Chores**
  - Updated `.gitignore` to exclude `.mypy_cache/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->