### PR TITLE
fix: use stable tsup version

### DIFF
--- a/templates/types/streaming/express/package.json
+++ b/templates/types/streaming/express/package.json
@@ -39,7 +39,7 @@
     "prettier": "^3.2.5",
     "prettier-plugin-organize-imports": "^3.2.4",
     "tsx": "^4.7.2",
-    "tsup": "^8.0.1",
+    "tsup": "8.1.0",
     "typescript": "^5.3.2"
   }
 }


### PR DESCRIPTION
Fix issue from `tsup`: https://github.com/egoist/tsup/issues/1157
We use a stable version for express and wait for tsup team fix it