### PR TITLE
chore: Use gpt-4o-mini as default

### DIFF
--- a/.changeset/strong-dryers-punch.md
+++ b/.changeset/strong-dryers-punch.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+Use gpt-4o-mini as default model

--- a/helpers/providers/openai.ts
+++ b/helpers/providers/openai.ts
@@ -8,7 +8,7 @@ import { questionHandlers } from "../../questions";
 
 const OPENAI_API_URL = "https://api.openai.com/v1";
 
-const DEFAULT_MODEL = "gpt-3.5-turbo";
+const DEFAULT_MODEL = "gpt-4o-mini";
 const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-large";
 
 export async function askOpenAIQuestions({

--- a/templates/types/streaming/express/src/controllers/engine/settings.ts
+++ b/templates/types/streaming/express/src/controllers/engine/settings.ts
@@ -55,7 +55,7 @@ export const initSettings = async () => {
 
 function initOpenAI() {
   Settings.llm = new OpenAI({
-    model: process.env.MODEL ?? "gpt-3.5-turbo",
+    model: process.env.MODEL ?? "gpt-4o-mini",
     maxTokens: process.env.LLM_MAX_TOKENS
       ? Number(process.env.LLM_MAX_TOKENS)
       : undefined,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the AI model from "gpt-3.5-turbo" to "gpt-4o-mini," potentially enhancing performance and response quality in the application. 

- **Bug Fixes**
	- Ensured that the transition to the new model maintains existing functionality without introducing any issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->