### PR TITLE
fix: ignore ts check grammar for regex

### DIFF
--- a/templates/components/llamaindex/typescript/streaming/suggestion.ts
+++ b/templates/components/llamaindex/typescript/streaming/suggestion.ts
@@ -41,6 +41,7 @@ export async function generateNextQuestions(
 // TODO: instead of parsing the LLM's result we can use structured predict, once LITS supports it
 function extractQuestions(text: string): string[] {
   // Extract the text inside the triple backticks
+  // @ts-ignore
   const contentMatch = text.match(/```(.*?)```/s);
   const content = contentMatch ? contentMatch[1] : "";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a comment in the code to clarify the use of `@ts-ignore` in the question extraction process. This aims to improve future implementation efforts without impacting current functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->