### PR TITLE
Fix starter questions not working in python backend

### DIFF
--- a/.changeset/stale-maps-own.md
+++ b/.changeset/stale-maps-own.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+Fix starter questions not working in python backend

--- a/templates/types/streaming/fastapi/app/api/routers/models.py
+++ b/templates/types/streaming/fastapi/app/api/routers/models.py
@@ -249,5 +249,3 @@ class ChatConfig(BaseModel):
                 ]
             }
         }
-        
-        

--- a/templates/types/streaming/fastapi/app/api/routers/models.py
+++ b/templates/types/streaming/fastapi/app/api/routers/models.py
@@ -237,6 +237,7 @@ class ChatConfig(BaseModel):
     starter_questions: Optional[List[str]] = Field(
         default=None,
         description="List of starter questions",
+        serialization_alias="starterQuestions"
     )
 
     class Config:
@@ -248,4 +249,5 @@ class ChatConfig(BaseModel):
                 ]
             }
         }
-        alias_generator = to_camel
+        
+        


### PR DESCRIPTION
When python backend is created, /config endpoint will not return conversation starters due to pydantic starter_questions case not converted to camel properly by alias_generator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a `serialization_alias` for the `starter_questions` field, allowing it to be serialized as `starterQuestions` for improved API compatibility.
	- Added a patch to ensure starter questions are processed correctly in the backend, enhancing functionality and user experience.

- **Changes**
	- Removed the automatic alias generator for clearer and more manual control over serialization naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->