### PR TITLE
fix: missing set private to false for default generate.py

### DIFF
--- a/.changeset/warm-numbers-report.md
+++ b/.changeset/warm-numbers-report.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+fix: missing set private to false for default generate.py

--- a/templates/types/streaming/fastapi/app/engine/generate.py
+++ b/templates/types/streaming/fastapi/app/engine/generate.py
@@ -64,6 +64,9 @@ def generate_datasource():
 
     # Get the stores and documents or create new ones
     documents = get_documents()
+    # Set private=false to mark the document as public (required for filtering)
+    for doc in documents:
+        doc.metadata["private"] = "false"
     docstore = get_doc_store()
     vector_store = get_vector_store()
 


### PR DESCRIPTION
To fix: https://github.com/ragapp/ragapp/issues/124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated document metadata to mark all retrieved documents as public, enhancing visibility and accessibility within the application.
  
- **Impact**
	- This change may affect how documents are filtered and accessed by users, ensuring they are categorized consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->