### PR TITLE
chore: add use window.ENV.BASE_URL as backendOrigin

### DIFF
--- a/templates/components/ui/html/chat/hooks/use-config.ts
+++ b/templates/components/ui/html/chat/hooks/use-config.ts
@@ -12,7 +12,15 @@ export function useClientConfig(): ChatConfig {
   const [config, setConfig] = useState<ChatConfig>();
 
   const backendOrigin = useMemo(() => {
-    return chatAPI ? new URL(chatAPI).origin : "";
+    if (chatAPI) {
+      return chatAPI || "";
+    } else {
+      if (typeof window !== "undefined") {
+        // Use BASE_URL from window.ENV
+        return (window as any).ENV?.BASE_URL || "";
+      }
+      return "";
+    }
   }, [chatAPI]);
 
   const configAPI = `${backendOrigin}/api/chat/config`;

--- a/templates/components/ui/html/chat/hooks/use-config.ts
+++ b/templates/components/ui/html/chat/hooks/use-config.ts
@@ -13,7 +13,7 @@ export function useClientConfig(): ChatConfig {
 
   const backendOrigin = useMemo(() => {
     if (chatAPI) {
-      return chatAPI || "";
+      return new URL(chatAPI).origin;
     } else {
       if (typeof window !== "undefined") {
         // Use BASE_URL from window.ENV


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved backend configuration handling for the chat component, enhancing flexibility across different runtime environments.

- **Bug Fixes**
	- Addressed issues with backend origin determination when `chatAPI` is not defined, ensuring a valid fallback is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->