### PR TITLE
fix: use modern module resolution for express

### DIFF
--- a/templates/types/streaming/express/tsconfig.json
+++ b/templates/types/streaming/express/tsconfig.json
@@ -5,7 +5,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "paths": {
       "@/*": ["./*"]
     }


### PR DESCRIPTION
https://github.com/run-llama/create-llama/issues/212#issuecomment-2271732136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated TypeScript configuration to enhance module resolution, optimizing compatibility with modern JavaScript tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->