### PR TITLE
fix: optional params in file upload API

### DIFF
--- a/.changeset/five-maps-arrive.md
+++ b/.changeset/five-maps-arrive.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+Fix: private file upload not working in Python without LlamaCloud

--- a/templates/types/streaming/fastapi/app/api/routers/upload.py
+++ b/templates/types/streaming/fastapi/app/api/routers/upload.py
@@ -14,7 +14,7 @@ logger = logging.getLogger("uvicorn")
 class FileUploadRequest(BaseModel):
     base64: str
     filename: str
-    params: Any
+    params: Any = None
 
 
 @r.post("")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- The `FileUploadRequest` class now allows for easier instantiation by defaulting the `params` attribute to `None`, simplifying the usage of this class for end-users. 
	- Enhanced reliability of file uploads with LlamaCloud, ensuring a smoother and more secure experience for users when uploading private files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->