### PR TITLE
fix: dont use props as state in chat suggestion component

### DIFF
--- a/.changeset/old-readers-fix.md
+++ b/.changeset/old-readers-fix.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+fix: dont use props as state in chat suggestion component

--- a/templates/types/streaming/nextjs/app/components/ui/chat/chat-message/chat-suggestedQuestions.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/chat-message/chat-suggestedQuestions.tsx
@@ -1,15 +1,15 @@
-import { useState } from "react";
 import { ChatHandler, SuggestedQuestionsData } from "..";
 
 export function SuggestedQuestions({
   questions,
   append,
+  isLastMessage,
 }: {
   questions: SuggestedQuestionsData;
   append: Pick<ChatHandler, "append">["append"];
+  isLastMessage: boolean;
 }) {
-  const [showQuestions, setShowQuestions] = useState(questions.length > 0);
-
+  const showQuestions = isLastMessage && questions.length > 0;
   return (
     showQuestions &&
     append !== undefined && (
@@ -19,7 +19,6 @@ export function SuggestedQuestions({
             key={index}
             onClick={() => {
               append({ role: "user", content: question });
-              setShowQuestions(false);
             }}
             className="text-sm italic hover:underline cursor-pointer"
           >

--- a/templates/types/streaming/nextjs/app/components/ui/chat/chat-message/index.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/chat-message/index.tsx
@@ -34,10 +34,12 @@ function ChatMessageContent({
   message,
   isLoading,
   append,
+  isLastMessage,
 }: {
   message: Message;
   isLoading: boolean;
   append: Pick<ChatHandler, "append">["append"];
+  isLastMessage: boolean;
 }) {
   const annotations = message.annotations as MessageAnnotation[] | undefined;
   if (!annotations?.length) return <Markdown content={message.content} />;
@@ -102,6 +104,7 @@ function ChatMessageContent({
         <SuggestedQuestions
           questions={suggestedQuestionsData[0]}
           append={append}
+          isLastMessage={isLastMessage}
         />
       ) : null,
     },
@@ -122,10 +125,12 @@ export default function ChatMessage({
   chatMessage,
   isLoading,
   append,
+  isLastMessage,
 }: {
   chatMessage: Message;
   isLoading: boolean;
   append: Pick<ChatHandler, "append">["append"];
+  isLastMessage: boolean;
 }) {
   const { isCopied, copyToClipboard } = useCopyToClipboard({ timeout: 2000 });
   return (
@@ -136,6 +141,7 @@ export default function ChatMessage({
           message={chatMessage}
           isLoading={isLoading}
           append={append}
+          isLastMessage={isLastMessage}
         />
         <Button
           onClick={() => copyToClipboard(chatMessage.content)}

--- a/templates/types/streaming/nextjs/app/components/ui/chat/chat-messages.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/chat-messages.tsx
@@ -69,6 +69,7 @@ export default function ChatMessages(
               chatMessage={m}
               isLoading={isLoadingMessage}
               append={props.append!}
+              isLastMessage={i === messageLength - 1}
             />
           );
         })}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced chat suggestion component for improved data handling and performance.
	- Introduced a new `isLastMessage` prop across multiple components to enhance rendering logic based on message context.

- **Bug Fixes**
	- Corrected the handling of properties in the chat suggestion component to prevent side effects and ensure consistent UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->