### PR TITLE
fix: keep origin upload filename

### DIFF
--- a/.changeset/strong-kids-brush.md
+++ b/.changeset/strong-kids-brush.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+fix: keep origin upload filename

--- a/templates/components/llamaindex/typescript/documents/helper.ts
+++ b/templates/components/llamaindex/typescript/documents/helper.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import crypto from "node:crypto";
 import { getExtractors } from "../../engine/loader";
 
 const MIME_TYPE_TO_EXT: Record<string, string> = {
@@ -11,9 +10,13 @@ const MIME_TYPE_TO_EXT: Record<string, string> = {
 
 const UPLOADED_FOLDER = "output/uploaded";
 
-export async function storeAndParseFile(fileBuffer: Buffer, mimeType: string) {
+export async function storeAndParseFile(
+  filename: string,
+  fileBuffer: Buffer,
+  mimeType: string,
+) {
   const documents = await loadDocuments(fileBuffer, mimeType);
-  const { filename } = await saveDocument(fileBuffer, mimeType);
+  await saveDocument(filename, fileBuffer, mimeType);
   for (const document of documents) {
     document.metadata = {
       ...document.metadata,
@@ -35,11 +38,14 @@ async function loadDocuments(fileBuffer: Buffer, mimeType: string) {
   return await reader.loadDataAsContent(fileBuffer);
 }
 
-async function saveDocument(fileBuffer: Buffer, mimeType: string) {
+async function saveDocument(
+  filename: string,
+  fileBuffer: Buffer,
+  mimeType: string,
+) {
   const fileExt = MIME_TYPE_TO_EXT[mimeType];
   if (!fileExt) throw new Error(`Unsupported document type: ${mimeType}`);
 
-  const filename = `${crypto.randomUUID()}.${fileExt}`;
   const filepath = `${UPLOADED_FOLDER}/${filename}`;
   const fileurl = `${process.env.FILESERVER_URL_PREFIX}/${filepath}`;
 

--- a/templates/components/llamaindex/typescript/documents/upload.ts
+++ b/templates/components/llamaindex/typescript/documents/upload.ts
@@ -27,6 +27,6 @@ export async function uploadDocument(
   }
 
   // run the pipeline for other vector store indexes
-  const documents = await storeAndParseFile(fileBuffer, mimeType);
+  const documents = await storeAndParseFile(filename, fileBuffer, mimeType);
   return runPipeline(index, documents);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced file upload functionality to preserve the original filename during the upload process.
	- Improved document handling by allowing users to specify filenames when saving documents.

- **Bug Fixes**
	- Resolved issues related to filename generation during file uploads, ensuring integrity and user experience.

- **Documentation**
	- Updated documentation to reflect changes in function parameters and usage related to file uploads and document saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->