### PR TITLE
chore: fix ts syntax

### DIFF
--- a/.changeset/green-cheetahs-behave.md
+++ b/.changeset/green-cheetahs-behave.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+Fix errors in building the frontend

--- a/templates/types/streaming/nextjs/app/components/ui/chat/chat-message/codeblock.tsx
+++ b/templates/types/streaming/nextjs/app/components/ui/chat/chat-message/codeblock.tsx
@@ -68,7 +68,7 @@ const CodeBlock: FC<Props> = memo(({ language, value }) => {
       3,
       true,
     )}${fileExtension}`;
-    const fileName = window.prompt("Enter file name" || "", suggestedFileName);
+    const fileName = window.prompt("Enter file name", suggestedFileName);
 
     if (!fileName) {
       // User pressed cancel on prompt.


### PR DESCRIPTION
I just got this error recently when running `pnpm build`, may be it's now an issue in new typescript complier:
```
./app/components/ui/chat/chat-message/codeblock.tsx:71:36
Type error: This kind of expression is always truthy.

  69 |       true,
  70 |     )}${fileExtension}`;
> 71 |     const fileName = window.prompt("Enter file name" || "", suggestedFileName);
     |                                    ^
  72 |
  73 |     if (!fileName) {
  74 |       // User pressed cancel on prompt.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Corrected the display of the prompt message in the CodeBlock component, ensuring users see the intended input message and suggested filename.
	- Resolved errors encountered during the frontend build process, enhancing overall stability and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->