### PR TITLE
chore: fixed llama-index-core@0.11.9

### DIFF
--- a/templates/types/multiagent/fastapi/pyproject.toml
+++ b/templates/types/multiagent/fastapi/pyproject.toml
@@ -12,7 +12,8 @@ generate = "app.engine.generate:generate_datasource"
 [tool.poetry.dependencies]
 python = "^3.11"
 llama-index-agent-openai = ">=0.3.0,<0.4.0"
-llama-index = "^0.11.4"
+llama-index = "0.11.9"
+llama-index-core = "0.11.9"
 fastapi = "^0.112.2"
 python-dotenv = "^1.0.0"
 uvicorn = { extras = ["standard"], version = "^0.23.2" }


### PR DESCRIPTION
The current template does not work with llama_index@0.11.10 and above.
This PR is to fixed the version at 0.11.9