### PR TITLE
fix: don't write the StopEvent from sub task to the stream

### DIFF
--- a/.changeset/eighty-berries-tie.md
+++ b/.changeset/eighty-berries-tie.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+Fix only produces one agent event

--- a/templates/types/multiagent/fastapi/app/agents/planner.py
+++ b/templates/types/multiagent/fastapi/app/agents/planner.py
@@ -129,7 +129,9 @@ class StructuredPlannerAgent(Workflow):
         )
         # bubble all events while running the executor to the planner
         async for event in handler.stream_events():
-            ctx.write_event_to_stream(event)
+            # Don't write the StopEvent from sub task to the stream
+            if type(event) is not StopEvent:
+                ctx.write_event_to_stream(event)
         result: AgentRunResult = await handler
         if self._verbose:
             print("=== Done executing sub task ===\n")

--- a/templates/types/multiagent/fastapi/app/examples/workflow.py
+++ b/templates/types/multiagent/fastapi/app/examples/workflow.py
@@ -133,5 +133,7 @@ Review:
         handler = agent.run(input=input, streaming=streaming)
         # bubble all events while running the executor to the planner
         async for event in handler.stream_events():
-            ctx.write_event_to_stream(event)
+            # Don't write the StopEvent from sub task to the stream
+            if type(event) is not StopEvent:
+                ctx.write_event_to_stream(event)
         return await handler


### PR DESCRIPTION
Ref: https://github.com/run-llama/llama_index/issues/16200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue that limited agent event production to a single event, enabling multiple events to be generated as intended.
	- Improved event handling by filtering out `StopEvent` instances during sub-task execution, enhancing the overall event streaming process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->