### PR TITLE
bump: use latest LITS

### DIFF
--- a/.changeset/modern-lemons-applaud.md
+++ b/.changeset/modern-lemons-applaud.md
@@ -2,4 +2,4 @@
 "create-llama": patch
 ---
 
-bump: use latest LITS
+bump: use LlamaIndexTS 0.6.18

--- a/helpers/env-variables.ts
+++ b/helpers/env-variables.ts
@@ -65,7 +65,7 @@ const getVectorDBEnvs = (
         {
           name: "PG_CONNECTION_STRING",
           description:
-            "For generating a connection URI, see https://docs.timescale.com/use-timescale/latest/services/create-a-service\nThe PostgreSQL connection string.",
+            "For generating a connection URI, see https://supabase.com/vector\nThe PostgreSQL connection string.",
         },
       ];
 

--- a/templates/components/engines/typescript/agent/chat.ts
+++ b/templates/components/engines/typescript/agent/chat.ts
@@ -1,6 +1,6 @@
 import {
+  BaseChatEngine,
   BaseToolWithCall,
-  ChatEngine,
   OpenAIAgent,
   QueryEngineTool,
 } from "llamaindex";
@@ -45,7 +45,7 @@ export async function createChatEngine(documentIds?: string[], params?: any) {
   const agent = new OpenAIAgent({
     tools,
     systemPrompt: process.env.SYSTEM_PROMPT,
-  }) as unknown as ChatEngine;
+  }) as unknown as BaseChatEngine;
 
   return agent;
 }

--- a/templates/components/vectordbs/typescript/llamacloud/queryFilter.ts
+++ b/templates/components/vectordbs/typescript/llamacloud/queryFilter.ts
@@ -1,7 +1,8 @@
-import { MetadataFilter, MetadataFilters } from "llamaindex";
+import type { MetadataFilter, MetadataFilters } from "@llamaindex/cloud/api";
 
 export function generateFilters(documentIds: string[]): MetadataFilters {
   // public documents don't have the "private" field or it's set to "false"
+  // @ts-ignore TODO: fix typing in @llamaindex/cloud/api
   const publicDocumentsFilter: MetadataFilter = {
     key: "private",
     operator: "is_empty",

--- a/templates/components/vectordbs/typescript/llamacloud/queryFilter.ts
+++ b/templates/components/vectordbs/typescript/llamacloud/queryFilter.ts
@@ -1,15 +1,17 @@
-import type { MetadataFilter, MetadataFilters } from "@llamaindex/cloud/api";
+import { CloudRetrieveParams, MetadataFilter } from "llamaindex";
 
-export function generateFilters(documentIds: string[]): MetadataFilters {
+export function generateFilters(documentIds: string[]) {
   // public documents don't have the "private" field or it's set to "false"
-  // @ts-ignore TODO: fix typing in @llamaindex/cloud/api
   const publicDocumentsFilter: MetadataFilter = {
     key: "private",
     operator: "is_empty",
   };
 
   // if no documentIds are provided, only retrieve information from public documents
-  if (!documentIds.length) return { filters: [publicDocumentsFilter] };
+  if (!documentIds.length)
+    return {
+      filters: [publicDocumentsFilter],
+    } as CloudRetrieveParams["filters"];
 
   const privateDocumentsFilter: MetadataFilter = {
     key: "file_id", // Note: LLamaCloud uses "file_id" to reference private document ids as "doc_id" is a restricted field in LlamaCloud
@@ -21,5 +23,5 @@ export function generateFilters(documentIds: string[]): MetadataFilters {
   return {
     filters: [publicDocumentsFilter, privateDocumentsFilter],
     condition: "or",
-  };
+  } as CloudRetrieveParams["filters"];
 }

--- a/templates/components/vectordbs/typescript/pg/generate.ts
+++ b/templates/components/vectordbs/typescript/pg/generate.ts
@@ -18,7 +18,9 @@ async function loadAndIndex() {
 
   // create postgres vector store
   const vectorStore = new PGVectorStore({
-    connectionString: process.env.PG_CONNECTION_STRING,
+    clientConfig: {
+      connectionString: process.env.PG_CONNECTION_STRING,
+    },
     schemaName: PGVECTOR_SCHEMA,
     tableName: PGVECTOR_TABLE,
   });

--- a/templates/components/vectordbs/typescript/pg/index.ts
+++ b/templates/components/vectordbs/typescript/pg/index.ts
@@ -9,7 +9,9 @@ import {
 export async function getDataSource(params?: any) {
   checkRequiredEnvVars();
   const pgvs = new PGVectorStore({
-    connectionString: process.env.PG_CONNECTION_STRING,
+    clientConfig: {
+      connectionString: process.env.PG_CONNECTION_STRING,
+    },
     schemaName: PGVECTOR_SCHEMA,
     tableName: PGVECTOR_TABLE,
   });

--- a/templates/types/streaming/express/package.json
+++ b/templates/types/streaming/express/package.json
@@ -21,7 +21,7 @@
     "dotenv": "^16.3.1",
     "duck-duck-scrape": "^2.2.5",
     "express": "^4.18.2",
-    "llamaindex": "0.6.17",
+    "llamaindex": "0.6.18",
     "pdf2json": "3.0.5",
     "ajv": "^8.12.0",
     "@e2b/code-interpreter": "0.0.9-beta.3",

--- a/templates/types/streaming/express/package.json
+++ b/templates/types/streaming/express/package.json
@@ -21,7 +21,7 @@
     "dotenv": "^16.3.1",
     "duck-duck-scrape": "^2.2.5",
     "express": "^4.18.2",
-    "llamaindex": "0.6.2",
+    "llamaindex": "0.6.17",
     "pdf2json": "3.0.5",
     "ajv": "^8.12.0",
     "@e2b/code-interpreter": "0.0.9-beta.3",

--- a/templates/types/streaming/nextjs/package.json
+++ b/templates/types/streaming/nextjs/package.json
@@ -27,7 +27,7 @@
     "duck-duck-scrape": "^2.2.5",
     "formdata-node": "^6.0.3",
     "got": "^14.4.1",
-    "llamaindex": "0.6.17",
+    "llamaindex": "0.6.18",
     "lucide-react": "^0.294.0",
     "next": "^14.2.4",
     "react": "^18.2.0",

--- a/templates/types/streaming/nextjs/package.json
+++ b/templates/types/streaming/nextjs/package.json
@@ -27,7 +27,7 @@
     "duck-duck-scrape": "^2.2.5",
     "formdata-node": "^6.0.3",
     "got": "^14.4.1",
-    "llamaindex": "0.6.2",
+    "llamaindex": "0.6.17",
     "lucide-react": "^0.294.0",
     "next": "^14.2.4",
     "react": "^18.2.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `llamaindex` dependency to version `0.6.18` for both the Express and Next.js streaming projects, ensuring access to the latest features and fixes.
- **Bug Fixes**
	- Incorporated the latest patches and improvements from the LlamaIndexTS dependency update.
- **Improvements**
	- Enhanced configuration structure for the PostgreSQL vector store, improving connection management.
	- Modified import statements for better compatibility with the latest `llamaindex` cloud API.
	- Updated the description for the `PG_CONNECTION_STRING` environment variable to reflect a new source for connection URI information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->