### PR TITLE
fix: .env not loaded on poetry run generate

### DIFF
--- a/.changeset/chilled-zebras-taste.md
+++ b/.changeset/chilled-zebras-taste.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+Fix: programmatically ensure index for LlamaCloud

--- a/.changeset/hungry-chairs-tie.md
+++ b/.changeset/hungry-chairs-tie.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+Fix .env not loaded on poetry run generate

--- a/templates/components/multiagent/python/app/api/routers/chat.py
+++ b/templates/components/multiagent/python/app/api/routers/chat.py
@@ -5,7 +5,7 @@ from app.api.routers.models import (
     ChatData,
 )
 from app.api.routers.vercel_response import VercelStreamResponse
-from app.engine import get_chat_engine
+from app.engine.engine import get_chat_engine
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, status
 
 chat_router = r = APIRouter()

--- a/templates/components/vectordbs/python/llamacloud/generate.py
+++ b/templates/components/vectordbs/python/llamacloud/generate.py
@@ -1,9 +1,9 @@
 # flake8: noqa: E402
 from dotenv import load_dotenv
 
-from app.engine.index import get_index
-
 load_dotenv()
+
+from app.engine.index import get_index
 
 import logging
 from llama_index.core.readers import SimpleDirectoryReader

--- a/templates/components/vectordbs/python/llamacloud/generate.py
+++ b/templates/components/vectordbs/python/llamacloud/generate.py
@@ -1,6 +1,7 @@
 # flake8: noqa: E402
 import os
 from dotenv import load_dotenv
+
 load_dotenv()
 
 from llama_cloud import PipelineType

--- a/templates/types/streaming/fastapi/app/api/routers/chat.py
+++ b/templates/types/streaming/fastapi/app/api/routers/chat.py
@@ -13,7 +13,7 @@ from app.api.routers.models import (
     SourceNodes,
 )
 from app.api.routers.vercel_response import VercelStreamResponse
-from app.engine import get_chat_engine
+from app.engine.engine import get_chat_engine
 from app.engine.query_filter import generate_filters
 
 chat_router = r = APIRouter()

--- a/templates/types/streaming/fastapi/app/engine/__init__.py
+++ b/templates/types/streaming/fastapi/app/engine/__init__.py
@@ -1,1 +1,0 @@
-from .engine import get_chat_engine as get_chat_engine


### PR DESCRIPTION
Calling `poetry run generate` did not use the variables in `.env` file (as `__init__.py` was imported before calling `load_dotenv`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with the `.env` file not being loaded during command execution, ensuring environment variables are recognized.
	- Implemented a fix to programmatically ensure the index for LlamaCloud, enhancing indexing reliability.

- **Refactor**
	- Updated import paths for the `get_chat_engine` function across multiple files to reflect a new module structure, while maintaining existing functionality and control flow.
	- Enhanced configuration management by centralizing environment variable handling within a new method.

- **Documentation**
	- Clarified the structure and accessibility of the `get_chat_engine` function in the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->