### PR TITLE
fix: missing params when init Astra vectorstore

### DIFF
--- a/.changeset/eight-cups-rhyme.md
+++ b/.changeset/eight-cups-rhyme.md
@@ -1,0 +1,5 @@
+---
+"create-llama": minor
+---
+
+Simplified default questions and added pro mode

--- a/templates/components/vectordbs/typescript/astra/generate.ts
+++ b/templates/components/vectordbs/typescript/astra/generate.ts
@@ -14,7 +14,12 @@ async function loadAndIndex() {
 
   // create vector store and a collection
   const collectionName = process.env.ASTRA_DB_COLLECTION!;
-  const vectorStore = new AstraDBVectorStore();
+  const vectorStore = new AstraDBVectorStore({
+    params: {
+      endpoint: process.env.ASTRA_DB_ENDPOINT!,
+      token: process.env.ASTRA_DB_APPLICATION_TOKEN!,
+    },
+  });
   await vectorStore.createAndConnect(collectionName, {
     vector: {
       dimension: parseInt(process.env.EMBEDDING_DIM!),

--- a/templates/components/vectordbs/typescript/astra/index.ts
+++ b/templates/components/vectordbs/typescript/astra/index.ts
@@ -5,7 +5,12 @@ import { checkRequiredEnvVars } from "./shared";
 
 export async function getDataSource(params?: any) {
   checkRequiredEnvVars();
-  const store = new AstraDBVectorStore();
+  const store = new AstraDBVectorStore({
+    params: {
+      endpoint: process.env.ASTRA_DB_ENDPOINT!,
+      token: process.env.ASTRA_DB_APPLICATION_TOKEN!,
+    },
+  });
   await store.connect(process.env.ASTRA_DB_COLLECTION!);
   return await VectorStoreIndex.fromVectorStore(store);
 }

--- a/templates/types/streaming/express/package.json
+++ b/templates/types/streaming/express/package.json
@@ -21,7 +21,7 @@
     "dotenv": "^16.3.1",
     "duck-duck-scrape": "^2.2.5",
     "express": "^4.18.2",
-    "llamaindex": "0.6.19",
+    "llamaindex": "0.6.21",
     "pdf2json": "3.0.5",
     "ajv": "^8.12.0",
     "@e2b/code-interpreter": "0.0.9-beta.3",

--- a/templates/types/streaming/nextjs/package.json
+++ b/templates/types/streaming/nextjs/package.json
@@ -27,7 +27,7 @@
     "duck-duck-scrape": "^2.2.5",
     "formdata-node": "^6.0.3",
     "got": "^14.4.1",
-    "llamaindex": "0.6.19",
+    "llamaindex": "0.6.21",
     "lucide-react": "^0.294.0",
     "next": "^14.2.4",
     "react": "^18.2.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with the "create-llama" functionality by ensuring all required parameters are correctly provided during the initialization of the Astra vectorstore.
	- Enhanced the configuration of the vector store by including necessary connection parameters sourced from environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->