### PR TITLE
[WIP] chore: bump vercel ai

### DIFF
--- a/templates/components/llamaindex/typescript/streaming/events.ts
+++ b/templates/components/llamaindex/typescript/streaming/events.ts
@@ -1,4 +1,4 @@
-import { StreamData } from "ai";
+import { DataStreamWriter } from "ai";
 import {
   CallbackManager,
   LLamaCloudFileService,
@@ -15,7 +15,7 @@ import { downloadFile } from "./file";
 const LLAMA_CLOUD_DOWNLOAD_FOLDER = "output/llamacloud";
 
 export function appendSourceData(
-  data: StreamData,
+  data: DataStreamWriter,
   sourceNodes?: NodeWithScore<Metadata>[],
 ) {
   if (!sourceNodes?.length) return;
@@ -27,7 +27,7 @@ export function appendSourceData(
       url: getNodeUrl(node.node.metadata),
       text: node.node.getContent(MetadataMode.NONE),
     }));
-    data.appendMessageAnnotation({
+    data.writeMessageAnnotation({
       type: "sources",
       data: {
         nodes,
@@ -38,9 +38,9 @@ export function appendSourceData(
   }
 }
 
-export function appendEventData(data: StreamData, title?: string) {
+export function appendEventData(data: DataStreamWriter, title?: string) {
   if (!title) return;
-  data.appendMessageAnnotation({
+  data.writeMessageAnnotation({
     type: "events",
     data: {
       title,
@@ -49,11 +49,11 @@ export function appendEventData(data: StreamData, title?: string) {
 }
 
 export function appendToolData(
-  data: StreamData,
+  data: DataStreamWriter,
   toolCall: ToolCall,
   toolOutput: ToolOutput,
 ) {
-  data.appendMessageAnnotation({
+  data.writeMessageAnnotation({
     type: "tools",
     data: {
       toolCall: {
@@ -69,7 +69,7 @@ export function appendToolData(
   });
 }
 
-export function createCallbackManager(stream: StreamData) {
+export function createCallbackManager(stream: DataStreamWriter) {
   const callbackManager = new CallbackManager();
 
   callbackManager.on("retrieve-end", (data) => {

--- a/templates/types/streaming/nextjs/package.json
+++ b/templates/types/streaming/nextjs/package.json
@@ -18,7 +18,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.1.0",
     "@llamaindex/chat-ui": "^0.2.0",
-    "ai": "^4.0.3",
+    "ai": "^4.1.16",
     "ajv": "^8.12.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
StreamData is deprecated, Use createDataStream, createDataStreamResponse, and pipeDataStreamToResponse instead
Change in this PR: 
https://github.com/vercel/ai/pull/3919/files#diff-44d4973726b4ae9362e9d6f34398def14a0fd80dc2d97fee6b6160f3910aa27e

Follow this example to update:
https://github.com/vercel/ai/blob/main/examples/next-openai/app/api/use-chat-persistence-single-message-tools/route.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced streaming responses deliver smoother, more reliable chat interactions with improved handling of message updates.
  
- **Chores**
  - Upgraded the AI package dependency to benefit from enhanced performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->