### PR TITLE
fix: fix broken document link and shadcn import issue

### DIFF
--- a/llama-index-server/README.md
+++ b/llama-index-server/README.md
@@ -110,7 +110,7 @@ When enabled, the server provides a chat interface at the root path (`/`) with:
 ### Custom UI Components
 
 You can add custom UI components for your workflow by providing `component_dir` config and adding custom .jsx or .tsx files to the directory.
-See [Custom UI Components](docs/custom_ui_component.md) for more details.
+See [Custom UI Components](https://github.com/run-llama/create-llama/blob/main/llama-index-server/docs/custom_ui_component.md) for more details.
 
 ## Development Mode
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation link for "Custom UI Components" to point to the correct GitHub URL.

- **New Features**
  - Expanded support for UI dependencies when generating React components, now including React, shadcn/ui, lucide-react, LlamaIndex's markdown-ui, and tailwind css (cn).

- **Refactor**
  - Improved organization of import statements and clarified instructions regarding supported UI dependencies in prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->