### PR TITLE
chore: test typescript e2e with node 20 and 22

### DIFF
--- a/.changeset/sixty-chefs-search.md
+++ b/.changeset/sixty-chefs-search.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+chore: test typescript e2e with node 20 and 22

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22]
         python-version: ["3.11"]
         os: [macos-latest, windows-latest, ubuntu-22.04]
         frameworks: ["nextjs"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated end-to-end testing to use Node.js versions 20 and 22 instead of 18 and 20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->