### PR TITLE
fix cannot catch the error raised from the workflow

### DIFF
--- a/.changeset/warm-mugs-feel.md
+++ b/.changeset/warm-mugs-feel.md
@@ -1,0 +1,5 @@
+---
+"@create-llama/llama-index-server": patch
+---
+
+fix cannot catch the error raised from the workflow

--- a/python/llama-index-server/llama_index/server/api/callbacks/stream_handler.py
+++ b/python/llama-index-server/llama_index/server/api/callbacks/stream_handler.py
@@ -25,6 +25,10 @@ class StreamHandler:
         """Cancel the workflow handler."""
         await self.workflow_handler.cancel_run()
 
+    async def wait_for_completion(self) -> Any:
+        """Wait for the workflow to finish."""
+        await self.workflow_handler
+
     async def stream_events(self) -> AsyncGenerator[Any, None]:
         """Stream events through the processor chain."""
         try:

--- a/python/llama-index-server/llama_index/server/api/routers/chat.py
+++ b/python/llama-index-server/llama_index/server/api/routers/chat.py
@@ -195,6 +195,7 @@ async def _stream_content(
                 if not isinstance(event, (AgentInput, AgentSetup)):
                     yield VercelStreamResponse.convert_data(event.model_dump())
 
+        await handler.wait_for_completion()
     except asyncio.CancelledError:
         logger.warning("Client cancelled the request!")
         await handler.cancel_run()

--- a/python/llama-index-server/tests/api/test_event_stream.py
+++ b/python/llama-index-server/tests/api/test_event_stream.py
@@ -31,6 +31,7 @@ def chat_request() -> ChatRequest:
 def mock_workflow_handler() -> AsyncMock:
     handler = AsyncMock(spec=WorkflowHandler)
     handler.accumulate_text = MagicMock()
+    handler.wait_for_completion = AsyncMock()
     return handler
 
 


### PR DESCRIPTION
fix: https://github.com/run-llama/create-llama/issues/683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where errors raised during workflow execution could not be properly caught, improving reliability of streaming chat responses.
- **Enhancements**
  - Improved streaming response handling to ensure workflows fully complete before finishing the stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->