### PR TITLE
Fix curl example in README templates

### DIFF
--- a/packages/create-llama/templates/components/agents/python/blog/README-template.md
+++ b/packages/create-llama/templates/components/agents/python/blog/README-template.md
@@ -42,7 +42,7 @@ You can test the endpoint with the following curl request:
 ```
 curl --location 'localhost:8000/api/chat' \
 --header 'Content-Type: application/json' \
---data '{ "messages": [{ "role": "user", "content": "Write a blog post about physical standards for letters" }] }'
+--data '{ "id": "unique-chat-id", "messages": [{ "role": "user", "content": "Write a blog post about physical standards for letters" }] }'
 ```
 
 You can start editing the API by modifying `app/api/routers/chat.py` or `app/examples/workflow.py`. The API auto-updates as you save the files.

--- a/packages/create-llama/templates/components/agents/python/financial_report/README-template.md
+++ b/packages/create-llama/templates/components/agents/python/financial_report/README-template.md
@@ -30,7 +30,7 @@ You can test the endpoint with the following curl request:
 ```
 curl --location 'localhost:8000/api/chat' \
 --header 'Content-Type: application/json' \
---data '{ "messages": [{ "role": "user", "content": "Create a report comparing the finances of Apple and Tesla" }] }'
+--data '{ "id": "unique-chat-id", "messages": [{ "role": "user", "content": "Create a report comparing the finances of Apple and Tesla" }] }'
 ```
 
 You can start editing the API by modifying `app/api/routers/chat.py` or `app/workflows/financial_report.py`. The API auto-updates as you save the files.

--- a/packages/create-llama/templates/components/agents/python/form_filling/README-template.md
+++ b/packages/create-llama/templates/components/agents/python/form_filling/README-template.md
@@ -36,7 +36,7 @@ You can test the endpoint with the following curl request:
 ```
 curl --location 'localhost:8000/api/chat' \
 --header 'Content-Type: application/json' \
---data '{ "messages": [{ "role": "user", "content": "What can you do?" }] }'
+--data '{ "id": "unique-chat-id", "messages": [{ "role": "user", "content": "What can you do?" }] }'
 ```
 
 You can start editing the API by modifying `app/api/routers/chat.py` or `app/workflows/form_filling.py`. The API auto-updates as you save the files.

--- a/packages/create-llama/templates/components/use-cases/python/agentic_rag/README-template.md
+++ b/packages/create-llama/templates/components/use-cases/python/agentic_rag/README-template.md
@@ -46,7 +46,7 @@ You can start by sending an request on the [chat UI](http://localhost:8000) or y
 ```
 curl --location 'localhost:8000/api/chat' \
 --header 'Content-Type: application/json' \
---data '{ "messages": [{ "role": "user", "content": "What standards for a letter exist?" }] }'
+--data '{ "id": "unique-chat-id", "messages": [{ "role": "user", "content": "What standards for a letter exist?" }] }'
 ```
 
 ## Learn More

--- a/packages/create-llama/templates/components/use-cases/python/code_generator/README-template.md
+++ b/packages/create-llama/templates/components/use-cases/python/code_generator/README-template.md
@@ -41,7 +41,7 @@ You can start by sending an request on the [chat UI](http://localhost:8000) or y
 ```
 curl --location 'localhost:8000/api/chat' \
 --header 'Content-Type: application/json' \
---data '{ "messages": [{ "role": "user", "content": "Create a report comparing the finances of Apple and Tesla" }] }'
+--data '{ "id": "unique-chat-id", "messages": [{ "role": "user", "content": "Create a report comparing the finances of Apple and Tesla" }] }'
 ```
 
 ## Customize the UI

--- a/packages/create-llama/templates/components/use-cases/python/deep_research/README-template.md
+++ b/packages/create-llama/templates/components/use-cases/python/deep_research/README-template.md
@@ -46,7 +46,7 @@ You can start by sending an request on the [chat UI](http://localhost:8000) or y
 ```
 curl --location 'localhost:8000/api/chat' \
 --header 'Content-Type: application/json' \
---data '{ "messages": [{ "role": "user", "content": "Create a report comparing the finances of Apple and Tesla" }] }'
+--data '{ "id": "unique-chat-id", "messages": [{ "role": "user", "content": "Create a report comparing the finances of Apple and Tesla" }] }'
 ```
 
 ## Customize the UI

--- a/packages/create-llama/templates/components/use-cases/python/document_generator/README-template.md
+++ b/packages/create-llama/templates/components/use-cases/python/document_generator/README-template.md
@@ -42,7 +42,7 @@ You can start by sending an request on the [chat UI](http://localhost:8000) or y
 ```
 curl --location 'localhost:8000/api/chat' \
 --header 'Content-Type: application/json' \
---data '{ "messages": [{ "role": "user", "content": "Create a report comparing the finances of Apple and Tesla" }] }'
+--data '{ "id": "unique-chat-id", "messages": [{ "role": "user", "content": "Create a report comparing the finances of Apple and Tesla" }] }'
 ```
 
 ## Customize the UI

--- a/packages/create-llama/templates/components/use-cases/python/financial_report/README-template.md
+++ b/packages/create-llama/templates/components/use-cases/python/financial_report/README-template.md
@@ -46,7 +46,7 @@ You can start by sending an request on the [chat UI](http://localhost:8000) or y
 ```
 curl --location 'localhost:8000/api/chat' \
 --header 'Content-Type: application/json' \
---data '{ "messages": [{ "role": "user", "content": "Create a report comparing the finances of Apple and Tesla" }] }'
+--data '{ "id": "unique-chat-id", "messages": [{ "role": "user", "content": "Create a report comparing the finances of Apple and Tesla" }] }'
 ```
 
 ## Learn More

--- a/packages/create-llama/templates/components/use-cases/python/hitl/README-template.md
+++ b/packages/create-llama/templates/components/use-cases/python/hitl/README-template.md
@@ -42,7 +42,7 @@ You can start by sending an request on the [chat UI](http://localhost:8000) or y
 ```
 curl --location 'localhost:8000/api/chat' \
 --header 'Content-Type: application/json' \
---data '{ "messages": [{ "role": "user", "content": "Show me the files in the current directory" }] }'
+--data '{ "id": "unique-chat-id", "messages": [{ "role": "user", "content": "Show me the files in the current directory" }] }'
 ```
 
 ## How does HITL work?

--- a/packages/create-llama/templates/components/use-cases/typescript/hitl/README-template.md
+++ b/packages/create-llama/templates/components/use-cases/typescript/hitl/README-template.md
@@ -31,7 +31,7 @@ You can start by sending an request on the [chat UI](http://localhost:8000) or y
 ```
 curl --location 'localhost:8000/api/chat' \
 --header 'Content-Type: application/json' \
---data '{ "messages": [{ "role": "user", "content": "Show me the files in the current directory" }] }'
+--data '{ "id": "unique-chat-id", "messages": [{ "role": "user", "content": "Show me the files in the current directory" }] }'
 ```
 
 ## How does HITL work?


### PR DESCRIPTION
Currently, running the curl command generated by create-llama yields an error:

```
$ curl --location 'localhost:8000/api/chat' \
--header 'Content-Type: application/json' \
--data '{ "messages": [{ "role": "user", "content": "What standards for a letter exist?" }] }'

{"detail":[{"type":"missing","loc":["body","id"],"msg":"Field required","input":{"messages":[{"role":"user","content":"What standards for a letter exist?"}]}}]}%   
```

I wasn't sure if the ID field should be optional or not. If it is supposed to be optional, I'd be happy to create a PR for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example curl commands in various README guides to include an "id" field in the JSON payload for the `/api/chat` endpoint, providing clearer instructions for request formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->